### PR TITLE
[dsl] Add clk and reset connection in the parent

### DIFF
--- a/pymtl/dsl/Component.py
+++ b/pymtl/dsl/Component.py
@@ -30,8 +30,9 @@ class Component( ComponentLevel6 ):
       
       # We hook up the added clk and reset signals here.
       try:
-        s.connect( s.clk, s.get_parent_object().clk )
-        s.connect( s.reset, s.get_parent_object().reset )
+        parent = s.get_parent_object()
+        parent.connect( s.clk, parent.clk )
+        parent.connect( s.reset, parent.reset )
       except AttributeError:
         pass
 


### PR DESCRIPTION
Add `clk` and `reset` to the parent component.