### PR TITLE
Compatible reduce function

### DIFF
--- a/pclib/cl/TestMemoryCL_test.py
+++ b/pclib/cl/TestMemoryCL_test.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function
 
 import random
 import struct
+from functools import reduce
 
 import pytest
 


### PR DESCRIPTION
In Python 3 `reduce` is no longer a built-in function. Explicit import from `functools` is needed before you refer to `reduce`