### PR TITLE
fix component name with struct parameter

### DIFF
--- a/pymtl3/passes/backends/verilog/testcases/test_cases.py
+++ b/pymtl3/passes/backends/verilog/testcases/test_cases.py
@@ -327,7 +327,7 @@ CaseConnectPassThroughLongNameComp = set_attributes( CaseConnectPassThroughLongN
     ''',
     'REF_SRC',
     '''\
-        module DUT__a840bd1c84c05ea2
+        module DUT__2ae3b6d12e9855d1
         (
           input logic [0:0] clk,
           input logic [31:0] in_,

--- a/pymtl3/passes/backends/verilog/util/utility.py
+++ b/pymtl3/passes/backends/verilog/util/utility.py
@@ -36,11 +36,6 @@ def get_component_unique_name( c_rtype ):
   param_name = param_hash.hexdigest()
   return comp_name + "__" + param_name
 
-  def get_string( obj ):
-    """Return the string that identifies `obj`"""
-    if isinstance(obj, type): return obj.__name__
-    return str( obj )
-
 def wrap( s ):
   col = shutil.get_terminal_size().columns
   return "\n".join(sum((textwrap.wrap(line, col) for line in s.split("\n")), []))

--- a/pymtl3/passes/rtlir/rtype/RTLIRDataType.py
+++ b/pymtl3/passes/rtlir/rtype/RTLIRDataType.py
@@ -11,13 +11,13 @@ is a data type object or simply a data type. RTLIR instance type Signal
 can be parameterized by the generated type objects.
 """
 from functools import reduce
+from hashlib import blake2b
 from math import ceil, log2
 
 import pymtl3.dsl as dsl
 from pymtl3.datatypes import Bits, is_bitstruct_class, is_bitstruct_inst
 
 from ..errors import RTLIRConversionError
-from ..util.utility import collect_objs, get_hashed_name
 
 
 class BaseRTLIRDataType:
@@ -111,7 +111,12 @@ class Struct( BaseRTLIRDataType ):
       return s._full_name
 
   def get_name( s ):
-    return get_hashed_name( s.cls.__name__, s.get_field_str() )
+    full_name = s.get_full_name()
+    if len(full_name) < 64:
+      return full_name
+    param_hash = blake2b(digest_size = 8)
+    param_hash.update(s.get_field_str().encode('ascii'))
+    return f'{s.cls.__name__}__{param_hash.hexdigest()}'
 
   # def get_file_info( s ):
     # return s.file_info

--- a/pymtl3/passes/rtlir/util/utility.py
+++ b/pymtl3/passes/rtlir/util/utility.py
@@ -5,7 +5,9 @@
 # Date   : Feb 13, 2019
 """Helper methods for RTLIR."""
 
-from hashlib import blake2b
+from pymtl3.datatypes import is_bitstruct_class
+
+from ..rtype.RTLIRDataType import get_rtlir_dtype
 
 
 def collect_objs( m, Type ):
@@ -29,7 +31,10 @@ def get_component_full_name( c_rtype ):
 
   def get_string( obj ):
     """Return the string that identifies `obj`"""
-    if isinstance(obj, type): return obj.__name__
+    if isinstance(obj, type):
+      if is_bitstruct_class(obj):
+        return get_rtlir_dtype( obj() ).get_name()
+      return obj.__name__
     return str( obj )
 
   comp_name = c_rtype.get_name()
@@ -52,10 +57,3 @@ def get_ordered_update_ff( m ):
   """Return a list of update-ff update blocks that have deterministic order"""
 
   return [ x for x in m.get_update_block_order() if x in m.get_update_ff() ]
-
-def get_hashed_name( obj_name, param_name ):
-  if len(f'{obj_name}__{param_name}') >= 64:
-    param_hash = blake2b(digest_size = 8)
-    param_hash.update(param_name.encode('ascii'))
-    param_name = param_hash.hexdigest()
-  return f'{obj_name}__{param_name}'


### PR DESCRIPTION
- Use full name of the struct (containing field information to disambiguate different bitstructs with the same name) when translating a component