### PR TITLE
fix verilator vcd

### DIFF
--- a/pymtl3/passes/backends/verilog/import_/VerilogVerilatorImportPass.py
+++ b/pymtl3/passes/backends/verilog/import_/VerilogVerilatorImportPass.py
@@ -426,6 +426,8 @@ class VerilogVerilatorImportPass( BasePass ):
     wrapper_name = ip_cfg.get_c_wrapper_path()
     verilator_xinit_value = ip_cfg.get_vl_xinit_value()
     verilator_xinit_seed = ip_cfg.get_vl_xinit_seed()
+    has_clk = int(ph_cfg.has_clk)
+
     ip_cfg.vprint("\n=====Generate C wrapper=====")
 
     # Generate port declarations for the verilated model in C

--- a/pymtl3/passes/backends/verilog/import_/verilator_wrapper_c_template.py
+++ b/pymtl3/passes/backends/verilog/import_/verilator_wrapper_c_template.py
@@ -13,6 +13,9 @@ template = \
 #include "verilated.h"
 #include "verilated_vcd_c.h"
 
+// set to true if the model has clk signal
+#define HAS_CLK {has_clk}
+
 // set to true when VCD tracing is enabled in Verilator
 #define DUMP_VCD {dump_vcd}
 
@@ -45,7 +48,6 @@ extern "C" {{
     #if DUMP_VCD
     void *        tfp;
     unsigned int  trace_time;
-    unsigned char prev_clk;
     #endif
 
   }} V{component_name}_t;
@@ -114,7 +116,6 @@ V{component_name}_t * create_model( const char *vcd_filename ) {{
 
     m->tfp        = (void *) tfp;
     m->trace_time = 0;
-    m->prev_clk   = 0;
   }}
   #endif
 
@@ -189,18 +190,18 @@ void seq_eval( V{component_name}_t * m ) {{
 
   // evaluate one time cycle
 
+  #if HAS_CLK
   model->clk = 0;
+  #endif
+
   model->eval();
 
   #if DUMP_VCD
   if ( m->_vcd_en ) {{
 
     // update simulation time only on clock toggle
-    if (m->prev_clk != model->clk) {{
-      m->trace_time += {half_cycle_time};
-      g_main_time += {half_cycle_time};
-    }}
-    m->prev_clk = model->clk;
+    m->trace_time += {half_cycle_time};
+    g_main_time   += {half_cycle_time};
 
     // dump current signal values
     VerilatedVcdC * tfp = (VerilatedVcdC *) m->tfp;
@@ -210,18 +211,18 @@ void seq_eval( V{component_name}_t * m ) {{
   }}
   #endif
 
+  #if HAS_CLK
   model->clk = 1;
+  #endif
+
   model->eval();
 
   #if DUMP_VCD
   if ( m->_vcd_en ) {{
 
     // update simulation time only on clock toggle
-    if (m->prev_clk != model->clk) {{
-      m->trace_time += {half_cycle_time};
-      g_main_time += {half_cycle_time};
-    }}
-    m->prev_clk = model->clk;
+    m->trace_time += {half_cycle_time};
+    g_main_time += {half_cycle_time};
 
     // dump current signal values
     VerilatedVcdC * tfp = (VerilatedVcdC *) m->tfp;

--- a/pymtl3/passes/backends/verilog/import_/verilator_wrapper_py_template.py
+++ b/pymtl3/passes/backends/verilog/import_/verilator_wrapper_py_template.py
@@ -114,7 +114,8 @@ class {component_name}( Component ):
 
     # Use non-attribute varialbe to reduce CPython bytecode count
     _ffi_m = s._ffi_m
-    _ffi_inst = s._ffi_inst
+    _ffi_inst_comb_eval = s._ffi_inst.comb_eval
+    _ffi_inst_seq_eval  = s._ffi_inst.seq_eval
 
     # declare the port interface
 {port_defs}
@@ -129,16 +130,15 @@ class {component_name}( Component ):
       # Set inputs
 {set_comb_input}
 
-      _ffi_inst.comb_eval( _ffi_m )
+      _ffi_inst_comb_eval( _ffi_m )
 
       # Write all outputs
 {set_comb_output}
 
-    if {has_clk}:
-      @update_ff
-      def seq_upblk():
-        # seq_eval will automatically tick clock
-        _ffi_inst.seq_eval( _ffi_m )
+    @update_ff
+    def seq_upblk():
+      # seq_eval will automatically tick clock in C land
+      _ffi_inst_seq_eval( _ffi_m )
 
   def assert_en( s, en ):
     # TODO: for verilator, any assertion failure will cause the C simulator

--- a/pymtl3/stdlib/test_utils/test_helpers.py
+++ b/pymtl3/stdlib/test_utils/test_helpers.py
@@ -55,7 +55,8 @@ def _recursive_set_vl_trace( m, dump_vcd ):
        m.get_metadata( VerilogTranslationImportPass.enable ) ) or \
       isinstance( m, VerilogPlaceholder ):
     m.set_metadata( VerilogVerilatorImportPass.vl_trace, True )
-    m.set_metadata( VerilogVerilatorImportPass.vl_trace_filename, dump_vcd )
+    vl_trace_filename = f"top{repr(m)[1:]}".replace('.','_')
+    m.set_metadata( VerilogVerilatorImportPass.vl_trace_filename, dump_vcd+"_"+vl_trace_filename )
   else:
     for child in m.get_child_components():
       _recursive_set_vl_trace( child, dump_vcd )


### PR DESCRIPTION
- fix verilator vcd file names when there are multiple verilator imported model
- fix verilator vcd dumping for models without clk signal