### PR TITLE
On-demand VCD dumping

### DIFF
--- a/pymtl3/passes/backends/verilog/import_/VerilogVerilatorImportConfigs.py
+++ b/pymtl3/passes/backends/verilog/import_/VerilogVerilatorImportConfigs.py
@@ -102,7 +102,7 @@ class VerilogVerilatorImportConfigs( BasePassConfigs ):
     # Top level port name that is used to enable VCD dumping when
     # `vl_trace_on_demand` is True. Assuming the port is an active-high
     # enable signal.
-    "vl_trace_on_demand_enable" : "",
+    "vl_trace_on_demand_portname" : "",
 
     # C-compilation options
     # These options will be passed to the C compiler to create a shared lib.
@@ -140,7 +140,7 @@ class VerilogVerilatorImportConfigs( BasePassConfigs ):
      "vl_trace_on_demand"):
       Checker( lambda v: isinstance(v, bool), "expects a boolean" ),
 
-    ("c_flags", "ld_flags", "ld_libs", "vl_trace_filename", "vl_trace_on_demand_enable"):
+    ("c_flags", "ld_flags", "ld_libs", "vl_trace_filename", "vl_trace_on_demand_portname"):
       Checker( lambda v: isinstance(v, str),  "expects a string" ),
 
     "vl_Wno_list": Checker( lambda v: isinstance(v, list) and all(w in VerilogPlaceholderConfigs.Warnings for w in v),

--- a/pymtl3/passes/backends/verilog/import_/VerilogVerilatorImportConfigs.py
+++ b/pymtl3/passes/backends/verilog/import_/VerilogVerilatorImportConfigs.py
@@ -96,6 +96,14 @@ class VerilogVerilatorImportConfigs( BasePassConfigs ):
     # With the default options, the frequency of PyMTL clock is 1GHz
     "vl_trace_cycle_time" : 100,
 
+    # Set to true to allow for on-demand VCD dumping
+    "vl_trace_on_demand" : False,
+
+    # Top level port name that is used to enable VCD dumping when
+    # `vl_trace_on_demand` is True. Assuming the port is an active-high
+    # enable signal.
+    "vl_trace_on_demand_enable" : "",
+
     # C-compilation options
     # These options will be passed to the C compiler to create a shared lib.
 
@@ -128,10 +136,11 @@ class VerilogVerilatorImportConfigs( BasePassConfigs ):
 
   Checkers = {
     ("enable", "verbose", "vl_enable_assert", "vl_line_trace", "vl_W_lint", "vl_W_style",
-     "vl_W_fatal", "vl_trace", "vl_coverage", "vl_line_coverage", "vl_toggle_coverage"):
+     "vl_W_fatal", "vl_trace", "vl_coverage", "vl_line_coverage", "vl_toggle_coverage",
+     "vl_trace_on_demand"):
       Checker( lambda v: isinstance(v, bool), "expects a boolean" ),
 
-    ("c_flags", "ld_flags", "ld_libs", "vl_trace_filename"):
+    ("c_flags", "ld_flags", "ld_libs", "vl_trace_filename", "vl_trace_on_demand_enable"):
       Checker( lambda v: isinstance(v, str),  "expects a string" ),
 
     "vl_Wno_list": Checker( lambda v: isinstance(v, list) and all(w in VerilogPlaceholderConfigs.Warnings for w in v),

--- a/pymtl3/passes/backends/verilog/import_/VerilogVerilatorImportPass.py
+++ b/pymtl3/passes/backends/verilog/import_/VerilogVerilatorImportPass.py
@@ -195,6 +195,22 @@ class VerilogVerilatorImportPass( BasePass ):
   #: Default value: ``100``
   vl_trace_cycle_time = MetadataKey(int)
 
+  #: Set to true to allow for on-demand VCD dumping
+  #:
+  #: Type: ``bool``; input
+  #:
+  #: Default value: ``False``
+  vl_trace_on_demand  = MetadataKey(bool)
+
+  #: Top level port name that is used to enable VCD dumping when
+  #: `vl_trace_on_demand` is True. Assuming the port is an active-high
+  #: enable signal.
+  #:
+  #: Type: ``str``; input
+  #:
+  #: Default value: ``""``
+  vl_trace_on_demand_enable = MetadataKey(str)
+
   #: Optional flags to be passed to the C compiler.
   #:
   #: Type: ``str``; input
@@ -437,6 +453,10 @@ class VerilogVerilatorImportPass( BasePass ):
     verilator_xinit_value = ip_cfg.get_vl_xinit_value()
     verilator_xinit_seed = ip_cfg.get_vl_xinit_seed()
     has_clk = int(ph_cfg.has_clk)
+
+    # On-demand VCD dumping configs
+    on_demand_dump_vcd = int(ip_cfg.vl_trace_on_demand)
+    on_demand_vcd_enable = str(ip_cfg.vl_trace_on_demand_enable)
 
     ip_cfg.vprint("\n=====Generate C wrapper=====")
 

--- a/pymtl3/passes/backends/verilog/import_/VerilogVerilatorImportPass.py
+++ b/pymtl3/passes/backends/verilog/import_/VerilogVerilatorImportPass.py
@@ -209,7 +209,7 @@ class VerilogVerilatorImportPass( BasePass ):
   #: Type: ``str``; input
   #:
   #: Default value: ``""``
-  vl_trace_on_demand_enable = MetadataKey(str)
+  vl_trace_on_demand_portname = MetadataKey(str)
 
   #: Optional flags to be passed to the C compiler.
   #:
@@ -456,7 +456,11 @@ class VerilogVerilatorImportPass( BasePass ):
 
     # On-demand VCD dumping configs
     on_demand_dump_vcd = int(ip_cfg.vl_trace_on_demand)
-    on_demand_vcd_enable = str(ip_cfg.vl_trace_on_demand_enable)
+    on_demand_vcd_enable = str(ip_cfg.vl_trace_on_demand_portname)
+    if on_demand_vcd_enable:
+      on_demand_vcd_enable = f"model->{on_demand_vcd_enable}"
+    else:
+      on_demand_vcd_enable = 0
 
     ip_cfg.vprint("\n=====Generate C wrapper=====")
 

--- a/pymtl3/passes/backends/verilog/import_/test/ImportedObject_test.py
+++ b/pymtl3/passes/backends/verilog/import_/test/ImportedObject_test.py
@@ -497,7 +497,7 @@ def test_incr_on_demand_vcd( do_test ):
       s.set_metadata( VerilogPlaceholderPass.has_reset, False )
       s.set_metadata( VerilogVerilatorImportPass.vl_trace, True )
       s.set_metadata( VerilogVerilatorImportPass.vl_trace_on_demand, True )
-      s.set_metadata( VerilogVerilatorImportPass.vl_trace_on_demand_enable, "vcd_en" )
+      s.set_metadata( VerilogVerilatorImportPass.vl_trace_on_demand_portname, "vcd_en" )
   a = VIncr()
   a.elaborate()
   a.apply( VerilogPlaceholderPass() )

--- a/pymtl3/passes/backends/verilog/import_/test/VIncr.v
+++ b/pymtl3/passes/backends/verilog/import_/test/VIncr.v
@@ -1,0 +1,23 @@
+module child (
+  input [9:0] in_,
+  output logic [9:0] out
+);
+  assign out = in_ + 1;
+endmodule
+
+module test_VIncr (
+  input [9:0] in_,
+  output logic [9:0] out,
+  output logic vcd_en
+);
+  logic [9:0] child_out;
+
+  child c (
+    .in_(in_),
+    .out(child_out)
+  );
+
+  assign out = child_out;
+
+  assign vcd_en = (in_[2:0] >= 4);
+endmodule

--- a/pymtl3/passes/backends/verilog/import_/verilator_wrapper_c_template.py
+++ b/pymtl3/passes/backends/verilog/import_/verilator_wrapper_c_template.py
@@ -19,6 +19,13 @@ template = \
 // set to true when VCD tracing is enabled in Verilator
 #define DUMP_VCD {dump_vcd}
 
+// set to true to enable on-demand VCD dumping
+#define ON_DEMAND_DUMP_VCD {on_demand_dump_vcd}
+
+// top level port to be used in on-demand VCD dumping; only dump vars when
+// that port has a non-zero value.
+#define ON_DEMAND_VCD_ENABLE {on_demand_vcd_enable}
+
 // set to true when Verilog module has line tracing
 #define VLINETRACE {external_trace}
 
@@ -197,7 +204,7 @@ void seq_eval( V{component_name}_t * m ) {{
   model->eval();
 
   #if DUMP_VCD
-  if ( m->_vcd_en ) {{
+  if ( m->_vcd_en && (model->ON_DEMAND_VCD_ENABLE || !ON_DEMAND_DUMP_VCD) ) {{
 
     // update simulation time only on clock toggle
     m->trace_time += {half_cycle_time};
@@ -218,7 +225,7 @@ void seq_eval( V{component_name}_t * m ) {{
   model->eval();
 
   #if DUMP_VCD
-  if ( m->_vcd_en ) {{
+  if ( m->_vcd_en && (model->ON_DEMAND_VCD_ENABLE || !ON_DEMAND_DUMP_VCD) ) {{
 
     // update simulation time only on clock toggle
     m->trace_time += {half_cycle_time};

--- a/pymtl3/passes/backends/verilog/import_/verilator_wrapper_c_template.py
+++ b/pymtl3/passes/backends/verilog/import_/verilator_wrapper_c_template.py
@@ -204,7 +204,7 @@ void seq_eval( V{component_name}_t * m ) {{
   model->eval();
 
   #if DUMP_VCD
-  if ( m->_vcd_en && (model->ON_DEMAND_VCD_ENABLE || !ON_DEMAND_DUMP_VCD) ) {{
+  if ( m->_vcd_en && (ON_DEMAND_VCD_ENABLE || !ON_DEMAND_DUMP_VCD) ) {{
 
     // update simulation time only on clock toggle
     m->trace_time += {half_cycle_time};
@@ -225,7 +225,7 @@ void seq_eval( V{component_name}_t * m ) {{
   model->eval();
 
   #if DUMP_VCD
-  if ( m->_vcd_en && (model->ON_DEMAND_VCD_ENABLE || !ON_DEMAND_DUMP_VCD) ) {{
+  if ( m->_vcd_en && (ON_DEMAND_VCD_ENABLE || !ON_DEMAND_DUMP_VCD) ) {{
 
     // update simulation time only on clock toggle
     m->trace_time += {half_cycle_time};


### PR DESCRIPTION
This PR adds new metadata support to enable VCD dumping only for an ROI. In order to do this your component hierarchy needs a top level port (active-high) that enables VCD dumping.