### PR TITLE
Add on-demand VCD support to model config

### DIFF
--- a/pymtl3/passes/backends/verilog/import_/VerilogVerilatorImportPass.py
+++ b/pymtl3/passes/backends/verilog/import_/VerilogVerilatorImportPass.py
@@ -658,6 +658,7 @@ class VerilogVerilatorImportPass( BasePass ):
       'vl_W_lint', 'vl_W_style', 'vl_W_fatal', 'vl_Wno_list',
       'vl_xinit', 'vl_trace',
       'vl_trace_timescale', 'vl_trace_cycle_time',
+      'vl_trace_on_demand', 'vl_trace_on_demand_portname',
       'c_flags', 'c_include_path', 'c_srcs',
       'ld_flags', 'ld_libs',
     ]

--- a/pymtl3/stdlib/test_utils/test_helpers.py
+++ b/pymtl3/stdlib/test_utils/test_helpers.py
@@ -67,12 +67,20 @@ def config_model_with_cmdline_opts( top, cmdline_opts, duts ):
   dump_vcd     = cmdline_opts[ 'dump_vcd'     ]
   dump_vtb     = cmdline_opts[ 'dump_vtb'     ]
 
+  if 'on_demand_vcd_portname' in cmdline_opts:
+    on_demand_vcd_portname = cmdline_opts['on_demand_vcd_portname']
+  else:
+    on_demand_vcd_portname = ""
+
   # Setup the model
 
   top.elaborate()
 
   if dump_vcd:
     _recursive_set_vl_trace( top, dump_vcd )
+
+  if on_demand_vcd_portname:
+    assert test_verilog, "--test-verilog has to be present to enable on-demand VCD!"
 
   if duts:
     dut_objs = []
@@ -89,6 +97,10 @@ def config_model_with_cmdline_opts( top, cmdline_opts, duts ):
       if dump_vcd:
         dut.set_metadata( VerilogVerilatorImportPass.vl_trace, True )
         dut.set_metadata( VerilogVerilatorImportPass.vl_trace_filename, dump_vcd )
+
+      if on_demand_vcd_portname:
+        dut.set_metadata( VerilogVerilatorImportPass.vl_trace_on_demand, True )
+        dut.set_metadata( VerilogVerilatorImportPass.vl_trace_on_demand_portname, on_demand_vcd_portname )
 
   top.apply( VerilogPlaceholderPass() )
   top = VerilogTranslationImportPass()( top )


### PR DESCRIPTION
Model configuration now looks at an optional field `on_demand_vcd_enable_portname` in the `cmdline_opts` dictionary