### PR TITLE
[Fix] Honor non-top port maps in subcomp declarations

### DIFF
--- a/pymtl3/passes/backends/verilog/VerilogPlaceholderConfigs.py
+++ b/pymtl3/passes/backends/verilog/VerilogPlaceholderConfigs.py
@@ -101,7 +101,7 @@ class VerilogPlaceholderConfigs( PlaceholderConfigs ):
           'exactly one of src_file and v_flist should be non-emtpy!' )
 
   def get_port_map( s ):
-    pmap = { p._dsl._my_name: name for p, name in s.port_map.items() }
+    pmap = { p._dsl.full_name: name for p, name in s.port_map.items() }
     return lambda name: pmap[name] if name in pmap else name
 
   def _add_to_checkers( s, checkers, cfg, chk ):

--- a/pymtl3/passes/backends/verilog/translation/structural/VStructuralTranslatorL4.py
+++ b/pymtl3/passes/backends/verilog/translation/structural/VStructuralTranslatorL4.py
@@ -38,12 +38,15 @@ class VStructuralTranslatorL4(
     direction = port_rtype.get_direction()
     if direction == 'input':
       direction += ' '
+    vname = port_id
+    port_full_name = f"{obj}.{port_id}"
+    ph_id = vname if pmap(port_full_name) == port_full_name else pmap(port_full_name)
     return {
         'direction' : direction,
         'data_type' : port_dtype['data_type'],
         'packed_type' : port_dtype['packed_type'],
         'id' : port_id,
-        'ph_id' : pmap(port_id),
+        'ph_id' : ph_id,
         'unpacked_type' : port_array_type['unpacked_type'],
     }
 
@@ -60,7 +63,8 @@ class VStructuralTranslatorL4(
         pmap = lambda x: x
       vname = f'{ifc_id}__{port_id}'
       pyname = vname.replace('__', '.')
-      ph_id = vname if pmap(pyname) == pyname else pmap(pyname)
+      port_full_name = f"{obj}.{pyname}"
+      ph_id = vname if pmap(port_full_name) == port_full_name else pmap(port_full_name)
       port_dtype = s.rtlir_data_type_translation( m, port_rtype.get_dtype() )
       direction = port_rtype.get_direction()
       if direction == 'input':


### PR DESCRIPTION
Behavior before: a name in the local scope is used while generating sub-component declarations (e.g., `s.pmx.proc.dmem.req.rdy` -> `rdy`). This breaks any port map on that component. 

Current behavior: a full name of port objects is used while generating sub-component declarations. This makes sure the translation pass honors the port map on that sub-component regardless of how many levels of nested interfaces are in it. 