### PR TITLE
[CI] Disable pypy CI job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ dist: xenial
 language: python
 # Use pypy3.6-7.0.0+ to have 1.12.0 version of CFFI which has `dlclose`
 python:
- - "pypy3.6-7.1.1"
  - "3.6"
  - "3.7"
+ # - "pypy3.6-7.1.1"
 
 env:
  - CONFIG=""

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ language: python
 python:
  - "3.6"
  - "3.7"
- # - "pypy3.6-7.1.1"
 
 env:
  - CONFIG=""


### PR DESCRIPTION
PyPy doesn't seem to work with the latest version of cryptography. This PR temporarily disables pypy on CI until we figure out a solution/workaround.