### PR TITLE
bypass queues should now support non-power-of-2 sizes

### DIFF
--- a/pymtl3/stdlib/stream/queues.py
+++ b/pymtl3/stdlib/stream/queues.py
@@ -301,10 +301,10 @@ class PipeQueueCtrlRTL( Component ):
 
       else:
         if s.recv_xfer:
-          s.tail <<= s.tail + 1
+          s.tail <<= s.tail + 1 if ( s.tail + 1  < num_entries ) else 0
 
         if s.send_xfer:
-          s.head <<= s.head + 1
+          s.head <<= s.head + 1 if ( s.head + 1  < num_entries ) else 0
 
         if s.recv_xfer & ~s.send_xfer:
           s.count <<= s.count + 1

--- a/pymtl3/stdlib/stream/queues.py
+++ b/pymtl3/stdlib/stream/queues.py
@@ -134,10 +134,10 @@ class NormalQueueCtrlRTL( Component ):
 
       else:
         if s.recv_xfer:
-          s.tail <<= s.tail + 1
+          s.tail <<= s.tail + 1 if ( s.tail < num_entries - 1 ) else 0
 
         if s.send_xfer:
-          s.head <<= s.head + 1
+          s.head <<= s.head + 1 if ( s.head < num_entries -1 ) else 0
 
         if s.recv_xfer & ~s.send_xfer:
           s.count <<= s.count + 1
@@ -301,10 +301,10 @@ class PipeQueueCtrlRTL( Component ):
 
       else:
         if s.recv_xfer:
-          s.tail <<= s.tail + 1 if ( s.tail + 1  < num_entries ) else 0
+          s.tail <<= s.tail + 1 if ( s.tail < num_entries - 1 ) else 0
 
         if s.send_xfer:
-          s.head <<= s.head + 1 if ( s.head + 1  < num_entries ) else 0
+          s.head <<= s.head + 1 if ( s.head < num_entries -1 ) else 0
 
         if s.recv_xfer & ~s.send_xfer:
           s.count <<= s.count + 1
@@ -496,10 +496,10 @@ class BypassQueueCtrlRTL( Component ):
 
       else:
         if s.recv_xfer:
-          s.tail <<= s.tail + 1
+          s.tail <<= s.tail + 1 if ( s.tail < num_entries - 1 ) else 0
 
         if s.send_xfer:
-          s.head <<= s.head + 1
+          s.head <<= s.head + 1 if ( s.head < num_entries -1 ) else 0
 
         if s.recv_xfer & ~s.send_xfer:
           s.count <<= s.count + 1

--- a/pymtl3/stdlib/stream/test/queues_test.py
+++ b/pymtl3/stdlib/stream/test/queues_test.py
@@ -111,6 +111,12 @@ def test_normal2_simple( cmdline_opts ):
   th.set_param( "top.dut.construct", num_entries = 2 )
   run_sim( th, cmdline_opts, duts=['dut'] )
 
+def test_normal3_simple( cmdline_opts ):
+  th = TestHarness( Bits16, NormalQueueRTL, test_msgs, test_msgs )
+  th.set_param( "top.sink.construct", arrival_time = arrival_pipe )
+  th.set_param( "top.dut.construct", num_entries = 3 )
+  run_sim( th, cmdline_opts, duts=['dut'] )
+
 def test_pipe1_simple( cmdline_opts ):
   th = TestHarness( Bits16, PipeQueueRTL, test_msgs, test_msgs )
   th.set_param( "top.sink.construct", arrival_time = arrival_pipe )
@@ -129,6 +135,12 @@ def test_pipe2_backpressure( cmdline_opts ):
   th.set_param( "top.dut.construct", num_entries = 2 )
   run_sim( th, cmdline_opts, duts=['dut'] )
 
+def test_pipe3_backpressure( cmdline_opts ):
+  th = TestHarness( Bits16, PipeQueueRTL, test_msgs, test_msgs )
+  th.set_param( "top.sink.construct", initial_delay = 20 )
+  th.set_param( "top.dut.construct", num_entries = 3 )
+  run_sim( th, cmdline_opts, duts=['dut'] )
+
 def test_bypass1_simple( cmdline_opts ):
   th = TestHarness( Bits16, BypassQueueRTL, test_msgs, test_msgs )
   th.set_param( "top.sink.construct", arrival_time = arrival_bypass )
@@ -145,6 +157,12 @@ def test_bypass2_sparse( cmdline_opts ):
   th = TestHarness( Bits16, BypassQueueRTL, test_msgs, test_msgs )
   th.set_param( "top.src.construct", interval_delay = 3 )
   th.set_param( "top.dut.construct", num_entries = 2 )
+  run_sim( th, cmdline_opts, duts=['dut'] )
+
+def test_bypass3_sparse( cmdline_opts ):
+  th = TestHarness( Bits16, BypassQueueRTL, test_msgs, test_msgs )
+  th.set_param( "top.src.construct", interval_delay = 3 )
+  th.set_param( "top.dut.construct", num_entries = 3 )
   run_sim( th, cmdline_opts, duts=['dut'] )
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Creating a pull request for a fix to the bypass queues in the ece5745-2021 version of pymtl3. Before they did not support queue sizes that were not a power of 2.