### PR TITLE
[VcdGen] Fix vcdwave in default pass

### DIFF
--- a/pymtl3/passes/PassGroups.py
+++ b/pymtl3/passes/PassGroups.py
@@ -37,7 +37,7 @@ class DefaultPassGroup( BasePass ):
   def __call__( s, top ):
 
     if s.vcdwave:
-      top.set_metadata( VcdGenerationPass.vcdwave, s.vcdwave )
+      top.set_metadata( VcdGenerationPass.vcd_file_name, s.vcdwave )
 
     if s.textwave:
       top.set_metadata( PrintTextWavePass.enable, True )


### PR DESCRIPTION
`VcdGenerationPass.vcdwave` was renamed to `VcdGenerationPass.vcd_file_name` at some point, but `DefaultPassGroup` was not updated to reflect this change