### PR TITLE
Support 3.7, 3.8. 3,9, 3.10 using one copy of codebase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ language: python
 python:
  - "3.6"
  - "3.7"
+ - "3.8"
+ - "3.9"
+ - "3.10"
 
 env:
  - CONFIG=""

--- a/pymtl3/dsl/ComponentLevel3.py
+++ b/pymtl3/dsl/ComponentLevel3.py
@@ -107,13 +107,13 @@ class ComponentLevel3( ComponentLevel2 ):
     blk_name = "_lambda__{}".format( repr(o).replace(".","_").replace("[", "_").replace("]", "_").replace(":", "_") )
     lambda_upblk = ast.FunctionDef(
       name=blk_name,
-      args=ast.arguments(args=[], vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=None, defaults=[]),
+      args=ast.arguments(args=[], vararg=None, kwonlyargs=[], kw_defaults=[], posonlyargs=[], kwarg=None, defaults=[]),
       body=[ast.AugAssign(target=lhs, op=ast.MatMult(), value=rhs, lineno=2, col_offset=6)],
       decorator_list=[],
       returns=None,
       lineno=1, col_offset=4,
     )
-    lambda_upblk_module = ast.Module(body=[ lambda_upblk ])
+    lambda_upblk_module = ast.Module(body=[ lambda_upblk ], type_ignores=[])
 
     # Manually wrap the lambda upblk with a closure function that adds the
     # desired variables to the closure of `_lambda__*`
@@ -134,7 +134,7 @@ class ComponentLevel3( ComponentLevel2 ):
       ast.FunctionDef(
           name="closure",
           args=ast.arguments(args=[ast.arg(arg="lambda_closure", annotation=None, lineno=1, col_offset=12)],
-                             vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=None, defaults=[]),
+                             vararg=None, kwonlyargs=[], kw_defaults=[], kwarg=None, posonlyargs=[], defaults=[]),
           body=[
             ast.Assign(
               targets=[ast.Name(id=var, ctx=ast.Store(), lineno=1+idx, col_offset=2)],
@@ -174,7 +174,7 @@ class ComponentLevel3( ComponentLevel2 ):
           returns=None,
           lineno=1, col_offset=0,
         )
-    ] )
+    ], type_ignores=[] )
 
     # In Python 3 we need to supply a dict as local to get the newly
     # compiled function from closure.

--- a/pymtl3/dsl/test/ComponentLevel2_test.py
+++ b/pymtl3/dsl/test/ComponentLevel2_test.py
@@ -98,6 +98,42 @@ def test_signal_require_type_or_int():
   except AssertionError as e:
     print(e)
     assert str(e).startswith( "RTL signal can only be of Bits type or bitstruct type" )
+    return
+  raise Exception("Should've thrown AssertionError.")
+
+def test_ast_invalid_slice1():
+
+  class Parametrized(ComponentLevel2):
+    def construct( s, nbits ):
+      s.x = Wire( nbits*2 )
+      @update
+      def upA():
+        print( s.x[1:2][1] )
+
+  a = Parametrized( 1 )
+  try:
+    a.elaborate()
+  except TypeError as e:
+    print(e)
+    return
+  raise Exception("Should've thrown TypeError.")
+
+def test_ast_invalid_slice2():
+
+  class Parametrized(ComponentLevel2):
+    def construct( s, nbits ):
+      s.x = Wire( nbits*2 )
+      @update
+      def upA():
+        print( s.x[1][1:2][1] )
+
+  a = Parametrized( 1 )
+  try:
+    a.elaborate()
+  except TypeError as e:
+    print(e)
+    return
+  raise Exception("Should've thrown TypeError.")
 
 def test_ast_caching_closure():
 


### PR DESCRIPTION
We have to use sys.version_info to switch between two different ast visit functions to address the difference between python<=3.8 and >=3.9