### PR TITLE
Fix vtb for arrays of vector ports

### DIFF
--- a/pymtl3/passes/backends/verilog/tbgen/test/VerilogTBGenPass_test.py
+++ b/pymtl3/passes/backends/verilog/tbgen/test/VerilogTBGenPass_test.py
@@ -14,8 +14,10 @@ from pymtl3.passes.backends.verilog import *
 from pymtl3.passes.rtlir.util.test_utility import do_test
 from pymtl3.stdlib.test_utils import TestVectorSimulator
 
-from ...testcases import CaseConnectArrayBits32FooIfcComp
-
+from ...testcases import (
+    CaseConnectArrayBits32Comp,
+    CaseConnectArrayBits32FooIfcComp
+)
 
 def local_do_test( _m ):
   _m.elaborate()
@@ -69,6 +71,18 @@ def test_normal_queue( do_test ):
 
 def test_CaseConnectArrayBits32FooIfcComp():
   case = CaseConnectArrayBits32FooIfcComp
+  _m = case.DUT()
+  _m.elaborate()
+  _m.set_metadata( VerilogTranslationImportPass.enable, True )
+  _m.apply( VerilogPlaceholderPass() )
+  m = VerilogTranslationImportPass()( _m )
+  m.set_metadata( VerilogTBGenPass.case_name, 'sb' )
+  m.apply( VerilogTBGenPass() )
+  sim = TestVectorSimulator( m, case.TV, case.TV_IN, case.TV_OUT )
+  sim.run_test()
+
+def test_CaseConnectArrayBits32Comp():
+  case = CaseConnectArrayBits32Comp
   _m = case.DUT()
   _m.elaborate()
   _m.set_metadata( VerilogTranslationImportPass.enable, True )

--- a/pymtl3/passes/backends/verilog/testcases/test_cases.py
+++ b/pymtl3/passes/backends/verilog/testcases/test_cases.py
@@ -40,6 +40,7 @@ from pymtl3.passes.testcases import (
     CaseBitSelOverPartSelComp,
     CaseBoolTmpVarComp,
     CaseChildExplicitModuleName,
+    CaseConnectArrayBits32Comp,
     CaseConnectArrayBits32FooIfcComp,
     CaseConnectArrayNestedIfcComp,
     CaseConnectArrayStructAttrToOutComp,

--- a/pymtl3/passes/testcases/test_cases.py
+++ b/pymtl3/passes/testcases/test_cases.py
@@ -2135,6 +2135,32 @@ class CaseConnectArrayBits32FooIfcComp:
       [ 1,     -2,    1,     -2, ],
   ]
 
+class CaseConnectArrayBits32Comp:
+  class DUT( Component ):
+    def construct( s ):
+      s.in_ = [ InPort(32) for _ in range(2) ]
+      s.out = [ OutPort(32) for _ in range(2) ]
+      for i in range(2):
+        connect( s.out[i], s.in_[i] )
+  TV_IN = \
+  _set(
+      'in_[0]',   Bits32,  0,
+      'in_[1]',   Bits32,  1,
+  )
+  TV_OUT = \
+  _check(
+      'out[0]',   Bits32,  2,
+      'out[1]',   Bits32,  3,
+  )
+  TV =\
+  [
+      [ 1,      0,    1,      0, ],
+      [ 0,     42,    0,     42, ],
+      [ 1,     42,    1,     42, ],
+      [ 1,     -1,    1,     -1, ],
+      [ 1,     -2,    1,     -2, ],
+  ]
+
 class CaseConnectArrayNestedIfcComp:
   class DUT( Component ):
     def construct( s ):


### PR DESCRIPTION
This PR fixes an issue of the VTB generation pass when a component with an array of vector ports is passed to `VTBGenerationPass`. The issue was not caught by the existing unit tests (we did have a test case for an array of _struct_ ports, though), so this PR also adds a unit test for the bug.