### PR TITLE
Suppress data_too_large warning from hypothesis in datatype tests

### DIFF
--- a/pymtl3/datatypes/test/strategies_test.py
+++ b/pymtl3/datatypes/test/strategies_test.py
@@ -171,7 +171,7 @@ def test_bitstruct( T ):
   @hypothesis.given(
     bs = pst.bitstructs(T)
   )
-  @hypothesis.settings( max_examples=16 )
+  @hypothesis.settings( max_examples=16, suppress_health_check=[hypothesis.HealthCheck.data_too_large] )
   def actual_test( bs ):
     assert isinstance( bs, T )
     print( bs )


### PR DESCRIPTION
This PR suppresses the `data_too_large` hypothesis warning in data type tests. We observed one occurrence of that warning on Github CI and it failed the integration test.  