### PR TITLE
Add support for changing toplevel module name through macro definition

### DIFF
--- a/pymtl3/passes/backends/verilog/tbgen/verilog_tbgen_v_template.py
+++ b/pymtl3/passes/backends/verilog/tbgen/verilog_tbgen_v_template.py
@@ -67,7 +67,15 @@ module {harness_name};
   // use 25% clock cycle, so #1 for setup #2 for sim #1 for hold
   always #(`CYCLE_TIME/2) clk = ~clk;
 
+  // DUT name
+  // By default we use the translated name of the Verilog component. But you can change
+  // that by defining the VTB_TOP_MODULE_NAME macro through the simulator command line
+  // options (e.g., for VCS you can do +define+VTB_TOP_MODULE_NAME=YourTopModuleName).
+`ifdef VTB_TOP_MODULE_NAME
+  `VTB_TOP_MODULE_NAME DUT
+`else
   {dut_name} DUT
+`endif
   (
     {dut_clk_decl},
     {dut_reset_decl},


### PR DESCRIPTION
This PR makes the generated Verilog testbenches even more reusable by allowing customizable toplevel module names through macro definitions. You can define the `VTB_TOP_MODULE_NAME` macro to change the module instantiated in the TB, which can be useful when you want to repurpose the RTL TB for gate-level netlists. If `VTB_TOP_MODULE_NAME` is not defined, the module name defaults to the translated Verilog module name.