### PR TITLE
Fixing subscript error with array of ifcs

### DIFF
--- a/pymtl3/passes/backends/verilog/tbgen/VerilogTBGenPass.py
+++ b/pymtl3/passes/backends/verilog/tbgen/VerilogTBGenPass.py
@@ -81,7 +81,7 @@ class VerilogTBGenPass( BasePass ):
 
         # Expand pname if we have an array (or arrays) of unexpanded vector ports
         expanded_pname = []
-        if isinstance( port, rt.Array ) and len(pname) == 1:
+        if isinstance( port, rt.Array ) and len(pname) == 1 and not bool(is_ifc):
           Q = deque( [ (pname[0], p_n_dim) ] )
           while Q:
             name, dim = Q.popleft()


### PR DESCRIPTION
The VTB generation pass does not correctly mangle the Python name of arrays of interfaces signals. This PR patches the VTB generation pass by checking if an `rt.Array` of ports belongs to an interface before expanding its Python name.