### PR TITLE
GitHub Actions: Add Python 3.10 and 3.11 to testing

### DIFF
--- a/.github/workflows/python-package-ci.yml
+++ b/.github/workflows/python-package-ci.yml
@@ -15,7 +15,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 '3.10', 3.11-dev ]
+        python-version: [ 3.7, 3.8, 3.9, '3.10', 3.11-dev ]
+
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-package-ci.yml
+++ b/.github/workflows/python-package-ci.yml
@@ -15,12 +15,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.6, 3.7, 3.8, 3.9 ] # FIXME github recognizes 3.10 as 3.1 lol
-
+        python-version: [ 3.7, 3.8, 3.9 '3.10', 3.11-dev ]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
>  \# FIXME github recognizes 3.10 as 3.1 lol

This is not a GitHub problem, it is a YAML problem. https://dev.to/hugovk/the-python-3-1-problem-85g

Python 3.11 release candidate 2 https://www.python.org/download/pre-releases