### PR TITLE
Fix Bug Caused By Struct with List Field

### DIFF
--- a/pymtl3/dsl/Connectable.py
+++ b/pymtl3/dsl/Connectable.py
@@ -213,10 +213,31 @@ class Signal( NamedObject, Connectable ):
           xd.top_level_signal = sd.top_level_signal
           xd.elaborate_top = sd.elaborate_top
 
-          xd.my_name     = name + "".join([ f"[{y}]" for y in indices ])
-          xd.full_name   = f"{sd.full_name}.{name}"
-          xd._my_name    = name
-          xd._my_indices = indices
+          # @bitstruct
+          # class SomeMsg:
+          #   a: [ Bits8, Bits8 ]
+          #   b: Bits32
+          # ...
+          # class A ( Component ):
+          #   def construct( s ):
+          #     s.struct_port = InPort( SomeMsg )
+          #
+          # Then, the newly created ports representing field a should be
+          # suffixed with the index, i.e., the name should be
+          # s.struct_port.a[0], s.struct_port.a[1]. Without the if
+          # statement below, both ports would have the same name
+          # s.struct_port.a, which can cause errors in simulation.
+          if is_bitstruct_class(s._dsl.Type):
+            xd.my_name = name + "".join([ f"[{y}]" for y in indices ])
+            xd.full_name   = f"{sd.full_name}.{name}"+"".join([ f"[{y}]" for y in indices ])
+            xd._my_name    = name
+            xd._my_indices = indices
+
+          else:
+            xd.my_name     = name + "".join([ f"[{y}]" for y in indices ])
+            xd.full_name   = f"{sd.full_name}.{name}"
+            xd._my_name    = name
+            xd._my_indices = indices
 
         if parent_is_list:
           parent.append( x )

--- a/pymtl3/passes/sim/test/DynamicSchedulePass_test.py
+++ b/pymtl3/passes/sim/test/DynamicSchedulePass_test.py
@@ -283,13 +283,15 @@ def test_struct_with_list_field():
       def up_abcd():
         s.a @= s.struct.b[1] + 1
 
-  x = Top()
-  x.elaborate()
-  x.apply( GenDAGPass() )
-  x.apply( DynamicSchedulePass() )
-  x.apply( PrepareSimPass(print_line_trace=False) )
-  x.sim_reset()
-  x.sim_tick()
+  dut = Top()
+  dut.elaborate()
+  dut.apply( GenDAGPass() )
+  dut.apply( DynamicSchedulePass() )
+  dut.apply( PrepareSimPass(print_line_trace=False) )
+  dut.sim_reset()
+  dut.sim_tick()
+  assert dut.a == 4
+  assert dut.b == 5
 
 def test_equal_top_level():
   class A(Component):


### PR DESCRIPTION
I found a bug when there is a port or wire that has a bitstruct type and the bitstruct type has a list field. Consider the following case:

```
@bitstruct
class SomeMsg:
  a: [ Bits8, Bits8 ]
  b: Bits32
...
class A ( Component ):
  def construct( s ):
    s.struct_port = InPort( SomeMsg )
```

During elaboration, we create a port for each bit struct field. However, the name for the list field (field `a` in this case) is not properly set. In the above example, we actually created two ports for field `a`, both with name `s.struct_port.a`. This can break our simulation passes. For example, in the `DynamicScheduePass`, if the field `a` is accessed in an update block in an SCC, it will generate a code block as follow:

```
def wrapped_SCC_1():
  N = 0
  while True:
    N += 1
    if N > 100:
      raise UpblkCyclicError("Combinational loop detected at runtime in {up_abcd, up_out} after 100 iters!")
    host=s; t1=host.struct_port.b.clone(); t2=host.struct_port.a.clone()
    scc_tick_func()
    host=s
    if host.struct.b != t1 or host.a != t2: continue
    # print( "SCC block1 is executed", num_iters, "times" )
    break
```

Which leads to the following error, since `host.a` is a list and a list does not have `clone` method.

```
E   AttributeError: 'list' object has no attribute 'clone'
```

I modified the naming logic for newly created port/signals a little to deal with such scenario, such that the two ports created for field `a` will have name `s.struct_port.a[0]` and `s.struct_port.a[1]`, which seems to fix this issue.

The bug was discovered while I was debugging the [VectorCGRA](https://github.com/tancheng/VectorCGRA) code of Dr. Tan (@tancheng).