### PR TITLE
Support parallel Verilog co-simulation through pytest-xdist

### DIFF
--- a/pymtl3/passes/backends/verilog/import_/VerilogVerilatorImportConfigs.py
+++ b/pymtl3/passes/backends/verilog/import_/VerilogVerilatorImportConfigs.py
@@ -26,7 +26,8 @@ class VerilogVerilatorImportConfigs( BasePassConfigs ):
     "enable" : False,
 
     # Enable verbose mode?
-    "verbose" : False,
+    # "verbose" : False,
+    "verbose" : True,
 
     # Trade off compilation time for fast simulation performance?
     # controls: vl_opt_level, vl_unroll_count

--- a/pymtl3/passes/backends/verilog/import_/VerilogVerilatorImportConfigs.py
+++ b/pymtl3/passes/backends/verilog/import_/VerilogVerilatorImportConfigs.py
@@ -26,8 +26,7 @@ class VerilogVerilatorImportConfigs( BasePassConfigs ):
     "enable" : False,
 
     # Enable verbose mode?
-    # "verbose" : False,
-    "verbose" : True,
+    "verbose" : False,
 
     # Trade off compilation time for fast simulation performance?
     # controls: vl_opt_level, vl_unroll_count

--- a/pymtl3/passes/backends/verilog/test/TranslationImport_xdist_test.py
+++ b/pymtl3/passes/backends/verilog/test/TranslationImport_xdist_test.py
@@ -5,7 +5,7 @@
 # Date   : Oct 11th, 2023
 """Test if Verilated models can be simulated in parallel."""
 
-import pytest, multiprocessing
+import os, pytest, multiprocessing
 
 from pymtl3.datatypes import Bits32
 from pymtl3.passes import DefaultPassGroup
@@ -13,8 +13,13 @@ from pymtl3.passes.backends.verilog import VerilogPlaceholderPass, VerilogTransl
 
 from ..testcases import Bits32VRegComp
 
+if 'CI' in os.environ:
+  MAX_XDIST_TEST_INSTS = 10
+else:
+  MAX_XDIST_TEST_INSTS = 500
+
 @pytest.mark.parametrize(
-  'test_id', list(range(500))
+  'test_id', list(range(MAX_XDIST_TEST_INSTS))
 )
 def test_verilator_co_simulation( test_id ):
   n_cycles = 100
@@ -33,4 +38,4 @@ def test_verilator_co_simulation( test_id ):
     m.sim_tick()
     assert m.q == Bits32(test_id + i)
 
-  # m.finalize()
+  m.finalize()

--- a/pymtl3/passes/backends/verilog/test/TranslationImport_xdist_test.py
+++ b/pymtl3/passes/backends/verilog/test/TranslationImport_xdist_test.py
@@ -1,0 +1,36 @@
+#=========================================================================
+# TranslationImport_xdist_test.py
+#=========================================================================
+# Author : Peitian Pan
+# Date   : Oct 11th, 2023
+"""Test if Verilated models can be simulated in parallel."""
+
+import pytest, multiprocessing
+
+from pymtl3.datatypes import Bits32
+from pymtl3.passes import DefaultPassGroup
+from pymtl3.passes.backends.verilog import VerilogPlaceholderPass, VerilogTranslationImportPass
+
+from ..testcases import Bits32VRegComp
+
+@pytest.mark.parametrize(
+  'test_id', list(range(500))
+)
+def test_verilator_co_simulation( test_id ):
+  n_cycles = 100
+
+  m = Bits32VRegComp()
+  m.elaborate()
+  m.set_metadata( VerilogTranslationImportPass.enable, True )
+  m.apply( VerilogPlaceholderPass() )
+  m = VerilogTranslationImportPass()( m )
+  m.apply( DefaultPassGroup() )
+
+  m.sim_reset()
+
+  for i in range(n_cycles):
+    m.d @= Bits32(test_id + i)
+    m.sim_tick()
+    assert m.q == Bits32(test_id + i)
+
+  # m.finalize()

--- a/pymtl3/passes/backends/verilog/translation/VerilogTranslationPass.py
+++ b/pymtl3/passes/backends/verilog/translation/VerilogTranslationPass.py
@@ -144,33 +144,6 @@ class VerilogTranslationPass( BasePass ):
           filename = fname.split('.sv')[0]
         else:
           filename = fname
-
-        output_file = filename + '.v'
-        temporary_file = filename + '.v.tmp'
-
-        # First write the file to a temporary file
-        is_same = False
-        with open( temporary_file, 'w' ) as output:
-          output.write( s.translator.hierarchy.src )
-          output.flush()
-          os.fsync( output )
-          output.close()
-
-        # `is_same` is set if there exists a file that has the same filename as
-        # `output_file`, and that file is the same as the temporary file
-        if ( os.path.exists(output_file) ):
-          is_same = verilog_cmp( temporary_file, output_file )
-
-        # Rename the temporary file to the output file
-        os.rename( temporary_file, output_file )
-
-        # Expose some attributes about the translation process
-        m.set_metadata( c.is_same,               is_same      )
-        m.set_metadata( c.translator,            s.translator )
-        m.set_metadata( c.translated,            True         )
-        m.set_metadata( c.translated_filename,   output_file  )
-        m.set_metadata( c.translated_top_module, module_name  )
-
       else:
         filename = f"{module_name}__pickled"
 

--- a/pymtl3/passes/backends/verilog/util/utility.py
+++ b/pymtl3/passes/backends/verilog/util/utility.py
@@ -61,10 +61,15 @@ def get_file_hash( file_path ):
     hash_inst.update(string)
     return hash_inst.hexdigest()
 
-def get_lean_verilog_file( file_path ):
-  with open(file_path) as fd:
-    file_v = [x for x in fd.readlines() if x != '\n' and not x.startswith('//')]
-  return file_v
+def get_lean_verilog( fd ):
+  return [x for x in fd.readlines() if x != '\n' and not x.startswith('//')]
+
+def get_lean_verilog_file( file_path_or_fd ):
+  if hasattr( file_path_or_fd, 'readlines' ):
+    return get_lean_verilog(file_path_or_fd)
+  else:
+    with open(file_path_or_fd) as fd:
+      return get_lean_verilog(fd)
 
 def get_hash_of_lean_verilog( file_path ):
   hash_inst = blake2b()


### PR DESCRIPTION
This PR enables parallel Verilog co-simulation through the xdist plugin of pytest. You can enable parallel Verilog co-sim via
```
% pytest -n 10 ../foo_test.py
```
where `-n 10 ` specifies 10 workers for the `foo_test` test file.