### PR TITLE
Verilog import fixes and revamp

### DIFF
--- a/pymtl3/passes/backends/generic/testcases/test_cases.py
+++ b/pymtl3/passes/backends/generic/testcases/test_cases.py
@@ -74,7 +74,7 @@ CaseTwoUpblksSliceComp = set_attributes( CaseTwoUpblksSliceComp,
     'freevars:\n',
     'REF_SRC',
     '''\
-        component DUT
+        component TwoUpblksSliceComp
         (
         port_decls:
           port_decl: in_ Port of Vector4
@@ -110,7 +110,7 @@ CaseTwoUpblksFreevarsComp = set_attributes( CaseTwoUpblksFreevarsComp,
     ''',
     'REF_SRC',
     '''\
-        component DUT
+        component TwoUpblksFreevarsComp
         (
         port_decls:
           port_decl: out Array[2] of Port
@@ -147,7 +147,7 @@ CaseBits32TmpWireComp = set_attributes( CaseBits32TmpWireComp,
     ''',
     'REF_SRC',
     '''\
-        component DUT
+        component Bits32TmpWireComp
         (
         port_decls:
           port_decl: in_ Port of Vector32
@@ -185,7 +185,7 @@ CaseBits32TmpWireAliasComp = set_attributes( CaseBits32TmpWireAliasComp,
     ''',
     'REF_SRC',
     '''\
-        component DUT
+        component Bits32TmpWireAliasComp
         (
         port_decls:
           port_decl: in_ Port of Vector32
@@ -224,7 +224,7 @@ CaseBits32MultiTmpWireComp = set_attributes( CaseBits32MultiTmpWireComp,
     ''',
     'REF_SRC',
     '''\
-        component DUT
+        component Bits32MultiTmpWireComp
         (
         port_decls:
           port_decl: in_ Port of Vector32
@@ -264,7 +264,7 @@ CaseBits32FreeVarToTmpVarComp = set_attributes( CaseBits32FreeVarToTmpVarComp,
     ''',
     'REF_SRC',
     '''\
-        component DUT
+        component Bits32FreeVarToTmpVarComp
         (
         port_decls:
           port_decl: out Port of Vector32
@@ -300,7 +300,7 @@ CaseBits32ConstBitsToTmpVarComp = set_attributes( CaseBits32ConstBitsToTmpVarCom
     ''',
     'REF_SRC',
     '''\
-        component DUT
+        component Bits32ConstBitsToTmpVarComp
         (
         port_decls:
           port_decl: out Port of Vector32
@@ -335,7 +335,7 @@ CaseBits32ConstIntToTmpVarComp = set_attributes( CaseBits32ConstIntToTmpVarComp,
     ''',
     'REF_SRC',
     '''\
-        component DUT
+        component Bits32ConstIntToTmpVarComp
         (
         port_decls:
           port_decl: out Port of Vector32
@@ -371,7 +371,7 @@ CaseStructTmpWireComp = set_attributes( CaseStructTmpWireComp,
     'REF_SRC',
     '''\
         struct Bits32Foo__foo_32
-        component DUT
+        component StructTmpWireComp
         (
         port_decls:
           port_decl: in_ Port of Struct Bits32Foo__foo_32
@@ -411,7 +411,7 @@ CaseTwoUpblksStructTmpWireComp = set_attributes( CaseTwoUpblksStructTmpWireComp,
     '''\
         struct Bits32Foo__foo_32
         struct Bits32Bar__bar_32
-        component DUT
+        component TwoUpblksStructTmpWireComp
         (
         port_decls:
           port_decl: in_bar Port of Struct Bits32Bar__bar_32
@@ -451,7 +451,7 @@ CaseBits32IfcTmpVarOutComp = set_attributes( CaseBits32IfcTmpVarOutComp,
     ''',
     'REF_SRC',
     '''\
-        component DUT
+        component Bits32IfcTmpVarOutComp
         (
         port_decls:
           port_decl: out Port of Vector32
@@ -490,7 +490,7 @@ CaseStructIfcTmpVarOutComp = set_attributes( CaseStructIfcTmpVarOutComp,
     'REF_SRC',
     '''\
         struct Bits32Foo__foo_32
-        component DUT
+        component StructIfcTmpVarOutComp
         (
         port_decls:
           port_decl: out Port of Vector32
@@ -546,7 +546,7 @@ CaseSubCompTmpDrivenComp = set_attributes( CaseSubCompTmpDrivenComp,
 
         endcomponent
 
-        component DUT
+        component SubCompTmpDrivenComp
         (
         port_decls:
           port_decl: out Port of Vector32
@@ -605,7 +605,7 @@ CaseSubCompFreeVarDrivenComp = set_attributes( CaseSubCompFreeVarDrivenComp,
 
         endcomponent
 
-        component DUT
+        component SubCompFreeVarDrivenComp
         (
         port_decls:
           port_decl: out Port of Vector32
@@ -631,10 +631,10 @@ CaseSubCompFreeVarDrivenComp = set_attributes( CaseSubCompFreeVarDrivenComp,
 
 CaseComponentArgsComp = set_attributes( CaseComponentArgsComp,
     'REF_NAME',
-    'DUT__foo_0__bar_002a',
+    'ComponentArgsComp__foo_0__bar_002a',
     'REF_SRC',
     '''\
-        component A__foo_0__bar_002a
+        component ComponentArgsComp__foo_0__bar_002a
         (
         port_decls:
         interface_decls:
@@ -653,10 +653,10 @@ CaseComponentArgsComp = set_attributes( CaseComponentArgsComp,
 
 CaseComponentDefaultArgsComp = set_attributes( CaseComponentDefaultArgsComp,
     'REF_NAME',
-    'DUT__foo_0__bar_002a',
+    'ComponentDefaultArgsComp__foo_0__bar_002a',
     'REF_SRC',
     '''\
-        component A__foo_0__bar_002a
+        component ComponentDefaultArgsComp__foo_0__bar_002a
         (
         port_decls:
         interface_decls:
@@ -675,10 +675,10 @@ CaseComponentDefaultArgsComp = set_attributes( CaseComponentDefaultArgsComp,
 
 CaseMixedDefaultArgsComp = set_attributes( CaseMixedDefaultArgsComp,
     'REF_NAME',
-    'DUT__foo_0__bar_002a__woo_00000000',
+    'MixedDefaultArgsComp__foo_0__bar_002a__woo_00000000',
     'REF_SRC',
     '''\
-        component A__foo_0__bar_002a__woo_00000000
+        component MixedDefaultArgsComp__foo_0__bar_002a__woo_00000000
         (
         port_decls:
         interface_decls:
@@ -697,7 +697,7 @@ CaseMixedDefaultArgsComp = set_attributes( CaseMixedDefaultArgsComp,
 
 CaseBits32PortOnly = set_attributes( CaseBits32PortOnly,
     'REF_NAME',
-    'DUT',
+    'Bits32PortOnly',
     'REF_PORT',
     '''\
         port_decls:
@@ -713,7 +713,7 @@ CaseBits32PortOnly = set_attributes( CaseBits32PortOnly,
     [ (rdt.Vector(1), 'Vector1'), (rdt.Vector(32), 'Vector32') ],
     'REF_SRC',
     '''\
-        component DUT
+        component Bits32PortOnly
         (
         port_decls:
           port_decl: in_ Port of Vector32
@@ -733,7 +733,7 @@ CaseBits32PortOnly = set_attributes( CaseBits32PortOnly,
 
 CaseBits32x5PortOnly = set_attributes( CaseBits32x5PortOnly,
     'REF_NAME',
-    'DUT',
+    'Bits32x5PortOnly',
     'REF_PORT',
     '''\
         port_decls:
@@ -741,7 +741,7 @@ CaseBits32x5PortOnly = set_attributes( CaseBits32x5PortOnly,
     ''',
     'REF_SRC',
     '''\
-        component DUT
+        component Bits32x5PortOnly
         (
         port_decls:
           port_decl: in_ Array[5] of Port
@@ -761,7 +761,7 @@ CaseBits32x5PortOnly = set_attributes( CaseBits32x5PortOnly,
 
 CaseWiresDrivenComp = set_attributes( CaseWiresDrivenComp,
     'REF_NAME',
-    'DUT',
+    'WiresDrivenComp',
     'REF_PORT',
     'port_decls:\n',
     'REF_WIRE',
@@ -772,7 +772,7 @@ CaseWiresDrivenComp = set_attributes( CaseWiresDrivenComp,
     ''',
     'REF_SRC',
     '''\
-        component DUT
+        component WiresDrivenComp
         (
         port_decls:
         interface_decls:
@@ -794,7 +794,7 @@ CaseWiresDrivenComp = set_attributes( CaseWiresDrivenComp,
 
 CaseBits32Wirex5DrivenComp = set_attributes( CaseBits32Wirex5DrivenComp,
     'REF_NAME',
-    'DUT',
+    'Bits32Wirex5DrivenComp',
     'REF_PORT',
     'port_decls:\n',
     'REF_WIRE',
@@ -804,7 +804,7 @@ CaseBits32Wirex5DrivenComp = set_attributes( CaseBits32Wirex5DrivenComp,
     ''',
     'REF_SRC',
     '''\
-        component DUT
+        component Bits32Wirex5DrivenComp
         (
         port_decls:
         interface_decls:
@@ -825,7 +825,7 @@ CaseBits32Wirex5DrivenComp = set_attributes( CaseBits32Wirex5DrivenComp,
 
 CaseBits32ClosureConstruct = set_attributes( CaseBits32ClosureConstruct,
     'REF_NAME',
-    'DUT',
+    'Bits32ClosureConstruct',
     'REF_PORT',
     '''\
         port_decls:
@@ -842,7 +842,7 @@ CaseBits32ClosureConstruct = set_attributes( CaseBits32ClosureConstruct,
     # Note that const_decls become emtpy because the constant s.fvar_ref
     # was not used in any upblks!
     '''\
-        component DUT
+        component Bits32ClosureConstruct
         (
         port_decls:
           port_decl: out Port of Vector32
@@ -874,7 +874,7 @@ CaseBits32ClosureConstruct = set_attributes( CaseBits32ClosureConstruct,
 
 CaseBits32ArrayClosureConstruct = set_attributes( CaseBits32ArrayClosureConstruct,
     'REF_NAME',
-    'DUT',
+    'Bits32ArrayClosureConstruct',
     'REF_PORT',
     '''\
         port_decls:
@@ -886,7 +886,7 @@ CaseBits32ArrayClosureConstruct = set_attributes( CaseBits32ArrayClosureConstruc
     'const_decls:\n',
     'REF_SRC',
     '''\
-        component DUT
+        component Bits32ArrayClosureConstruct
         (
         port_decls:
           port_decl: out Port of Vector32
@@ -914,7 +914,7 @@ CaseBits32ArrayClosureConstruct = set_attributes( CaseBits32ArrayClosureConstruc
 
 CaseConnectBitSelToOutComp = set_attributes( CaseConnectBitSelToOutComp,
     'REF_NAME',
-    'DUT',
+    'ConnectBitSelToOutComp',
     'REF_PORT',
     '''\
         port_decls:
@@ -932,7 +932,7 @@ CaseConnectBitSelToOutComp = set_attributes( CaseConnectBitSelToOutComp,
     ''',
     'REF_SRC',
     '''\
-        component DUT
+        component ConnectBitSelToOutComp
         (
         port_decls:
           port_decl: in_ Port of Vector32
@@ -954,7 +954,7 @@ CaseConnectBitSelToOutComp = set_attributes( CaseConnectBitSelToOutComp,
 
 CaseConnectSliceToOutComp = set_attributes( CaseConnectSliceToOutComp,
     'REF_NAME',
-    'DUT',
+    'ConnectSliceToOutComp',
     'REF_PORT',
     '''\
         port_decls:
@@ -972,7 +972,7 @@ CaseConnectSliceToOutComp = set_attributes( CaseConnectSliceToOutComp,
     ''',
     'REF_SRC',
     '''\
-        component DUT
+        component ConnectSliceToOutComp
         (
         port_decls:
           port_decl: in_ Port of Vector32
@@ -994,7 +994,7 @@ CaseConnectSliceToOutComp = set_attributes( CaseConnectSliceToOutComp,
 
 CaseConnectPortIndexComp = set_attributes( CaseConnectPortIndexComp,
     'REF_NAME',
-    'DUT',
+    'ConnectPortIndexComp',
     'REF_PORT',
     '''\
         port_decls:
@@ -1012,7 +1012,7 @@ CaseConnectPortIndexComp = set_attributes( CaseConnectPortIndexComp,
     ''',
     'REF_SRC',
     '''\
-        component DUT
+        component ConnectPortIndexComp
         (
         port_decls:
           port_decl: in_ Array[5] of Port
@@ -1034,7 +1034,7 @@ CaseConnectPortIndexComp = set_attributes( CaseConnectPortIndexComp,
 
 CaseConnectInToWireComp = set_attributes( CaseConnectInToWireComp,
     'REF_NAME',
-    'DUT',
+    'ConnectInToWireComp',
     'REF_PORT',
     '''\
         port_decls:
@@ -1060,7 +1060,7 @@ CaseConnectInToWireComp = set_attributes( CaseConnectInToWireComp,
     ''',
     'REF_SRC',
     '''\
-        component DUT
+        component ConnectInToWireComp
         (
         port_decls:
           port_decl: in_ Array[5] of Port
@@ -1088,7 +1088,7 @@ CaseConnectInToWireComp = set_attributes( CaseConnectInToWireComp,
 
 CaseConnectConstToOutComp = set_attributes( CaseConnectConstToOutComp,
     'REF_NAME',
-    'DUT',
+    'ConnectConstToOutComp',
     'REF_PORT',
     '''\
         port_decls:
@@ -1108,7 +1108,7 @@ CaseConnectConstToOutComp = set_attributes( CaseConnectConstToOutComp,
     ''',
     'REF_SRC',
     '''\
-        component DUT
+        component ConnectConstToOutComp
         (
         port_decls:
           port_decl: out Port of Vector32
@@ -1129,7 +1129,7 @@ CaseConnectConstToOutComp = set_attributes( CaseConnectConstToOutComp,
 
 CaseStructPortOnly = set_attributes( CaseStructPortOnly,
     'REF_NAME',
-    'DUT',
+    'StructPortOnly',
     'REF_PORT',
     '''\
         port_decls:
@@ -1144,7 +1144,7 @@ CaseStructPortOnly = set_attributes( CaseStructPortOnly,
     'REF_SRC',
     '''\
         struct Bits32Foo__foo_32
-        component DUT
+        component StructPortOnly
         (
         port_decls:
           port_decl: in_ Port of Struct Bits32Foo__foo_32
@@ -1166,7 +1166,7 @@ CaseStructPortOnly = set_attributes( CaseStructPortOnly,
 
 CaseStructWireDrivenComp = set_attributes( CaseStructWireDrivenComp,
     'REF_NAME',
-    'DUT',
+    'StructWireDrivenComp',
     'REF_PORT',
     'port_decls:\n',
     'REF_WIRE',
@@ -1181,7 +1181,7 @@ CaseStructWireDrivenComp = set_attributes( CaseStructWireDrivenComp,
     'REF_SRC',
     '''\
         struct Bits32Foo__foo_32
-        component DUT
+        component StructWireDrivenComp
         (
         port_decls:
         interface_decls:
@@ -1204,7 +1204,7 @@ CaseStructWireDrivenComp = set_attributes( CaseStructWireDrivenComp,
 
 CaseStructConstComp = set_attributes( CaseStructConstComp,
     'REF_NAME',
-    'DUT',
+    'StructConstComp',
     'REF_PORT',
     'port_decls:\n',
     'REF_WIRE',
@@ -1218,7 +1218,7 @@ CaseStructConstComp = set_attributes( CaseStructConstComp,
     'connections:\n',
     'REF_SRC',
     '''\
-        component DUT
+        component StructConstComp
         (
         port_decls:
         interface_decls:
@@ -1239,7 +1239,7 @@ CaseStructConstComp = set_attributes( CaseStructConstComp,
 
 CaseStructx5PortOnly = set_attributes( CaseStructx5PortOnly,
     'REF_NAME',
-    'DUT',
+    'Structx5PortOnly',
     'REF_PORT',
     '''\
         port_decls:
@@ -1254,7 +1254,7 @@ CaseStructx5PortOnly = set_attributes( CaseStructx5PortOnly,
     'REF_SRC',
     '''\
         struct Bits32Foo__foo_32
-        component DUT
+        component Structx5PortOnly
         (
         port_decls:
           port_decl: in_ Array[5] of Port
@@ -1276,7 +1276,7 @@ CaseStructx5PortOnly = set_attributes( CaseStructx5PortOnly,
 
 CaseNestedStructPortOnly = set_attributes( CaseNestedStructPortOnly,
     'REF_NAME',
-    'DUT',
+    'NestedStructPortOnly',
     'REF_PORT',
     '''\
         port_decls:
@@ -1292,7 +1292,7 @@ CaseNestedStructPortOnly = set_attributes( CaseNestedStructPortOnly,
     '''\
         struct Bits32Foo__foo_32
         struct NestedBits32Foo__foo_Bits32Foo__foo_32
-        component DUT
+        component NestedStructPortOnly
         (
         port_decls:
           port_decl: in_ Port of Struct NestedBits32Foo__foo_Bits32Foo__foo_32
@@ -1317,7 +1317,7 @@ CaseNestedStructPortOnly = set_attributes( CaseNestedStructPortOnly,
 
 CaseNestedPackedArrayStructComp = set_attributes( CaseNestedPackedArrayStructComp,
     'REF_NAME',
-    'DUT',
+    'NestedPackedArrayStructComp',
     'REF_PORT',
     '''\
         port_decls:
@@ -1337,7 +1337,7 @@ CaseNestedPackedArrayStructComp = set_attributes( CaseNestedPackedArrayStructCom
     '''\
         struct Bits32x5Foo__foo_32x5
         struct NestedStructPackedArray__foo_Bits32x5Foo__foo_32x5x5
-        component DUT
+        component NestedPackedArrayStructComp
         (
         port_decls:
           port_decl: in_ Port of Struct NestedStructPackedArray__foo_Bits32x5Foo__foo_32x5x5
@@ -1364,7 +1364,7 @@ CaseNestedPackedArrayStructComp = set_attributes( CaseNestedPackedArrayStructCom
 
 CaseConnectValRdyIfcComp = set_attributes( CaseConnectValRdyIfcComp,
     'REF_NAME',
-    'DUT',
+    'ConnectValRdyIfcComp',
     'REF_IFC',
     '''\
         interface_decls:
@@ -1388,7 +1388,7 @@ CaseConnectValRdyIfcComp = set_attributes( CaseConnectValRdyIfcComp,
     ''',
     'REF_SRC',
     '''\
-        component DUT
+        component ConnectValRdyIfcComp
         (
         port_decls:
         interface_decls:
@@ -1420,7 +1420,7 @@ CaseConnectValRdyIfcComp = set_attributes( CaseConnectValRdyIfcComp,
 
 CaseArrayBits32IfcInComp = set_attributes( CaseArrayBits32IfcInComp,
     'REF_NAME',
-    'DUT',
+    'ArrayBits32IfcInComp',
     'REF_IFC',
     '''\
         interface_decls:
@@ -1435,7 +1435,7 @@ CaseArrayBits32IfcInComp = set_attributes( CaseArrayBits32IfcInComp,
     ''',
     'REF_SRC',
     '''\
-        component DUT
+        component ArrayBits32IfcInComp
         (
         port_decls:
           port_decl: out Port of Vector32
@@ -1459,7 +1459,7 @@ CaseArrayBits32IfcInComp = set_attributes( CaseArrayBits32IfcInComp,
 
 CaseConnectArrayNestedIfcComp = set_attributes( CaseConnectArrayNestedIfcComp,
     'REF_NAME',
-    'DUT',
+    'ConnectArrayNestedIfcComp',
     'REF_IFC',
     '''\
         interface_decls:
@@ -1486,7 +1486,7 @@ CaseConnectArrayNestedIfcComp = set_attributes( CaseConnectArrayNestedIfcComp,
     ''',
     'REF_SRC',
     '''\
-        component DUT
+        component ConnectArrayNestedIfcComp
         (
         port_decls:
         interface_decls:
@@ -1521,7 +1521,7 @@ CaseConnectArrayNestedIfcComp = set_attributes( CaseConnectArrayNestedIfcComp,
 
 CaseBits32ConnectSubCompAttrComp = set_attributes( CaseBits32ConnectSubCompAttrComp,
     'REF_NAME',
-    'DUT',
+    'Bits32ConnectSubCompAttrComp',
     'REF_CONN',
     '''\
         connections:
@@ -1554,7 +1554,7 @@ CaseBits32ConnectSubCompAttrComp = set_attributes( CaseBits32ConnectSubCompAttrC
 
         endcomponent
 
-        component DUT
+        component Bits32ConnectSubCompAttrComp
         (
         port_decls:
           port_decl: out Port of Vector32
@@ -1579,7 +1579,7 @@ CaseBits32ConnectSubCompAttrComp = set_attributes( CaseBits32ConnectSubCompAttrC
 
 CaseConnectSubCompIfcHierarchyComp = set_attributes( CaseConnectSubCompIfcHierarchyComp,
     'REF_NAME',
-    'DUT',
+    'ConnectSubCompIfcHierarchyComp',
     'REF_CONN',
     '''\
         connections:
@@ -1627,7 +1627,7 @@ CaseConnectSubCompIfcHierarchyComp = set_attributes( CaseConnectSubCompIfcHierar
 
         endcomponent
 
-        component DUT
+        component ConnectSubCompIfcHierarchyComp
         (
         port_decls:
           port_decl: out Port of Vector32

--- a/pymtl3/passes/backends/verilog/import_/VerilogVerilatorImportPass.py
+++ b/pymtl3/passes/backends/verilog/import_/VerilogVerilatorImportPass.py
@@ -581,7 +581,7 @@ class VerilogVerilatorImportPass( BasePass ):
 
     # External trace function definition
     if ip_cfg.vl_line_trace:
-      external_trace_c_def = f'void trace( V{ip_cfg.translated_top_module}_t *, char * );'
+      external_trace_c_def = f'void V{ip_cfg.translated_top_module}_line_trace( V{ip_cfg.translated_top_module}_t *, char * );'
     else:
       external_trace_c_def = ''
 

--- a/pymtl3/passes/backends/verilog/import_/verilator_wrapper_c_template.py
+++ b/pymtl3/passes/backends/verilog/import_/verilator_wrapper_c_template.py
@@ -210,7 +210,7 @@ void V{component_name}_seq_eval( V{component_name}_t * m ) {{
   model->eval();
 
   #if DUMP_VCD
-  if ( m->vcd_en && (ON_DEMAND_VCD_ENABLE || !ON_DEMAND_DUMP_VCD) ) {{
+  if ( m->_cffi_vcd_en && (ON_DEMAND_VCD_ENABLE || !ON_DEMAND_DUMP_VCD) ) {{
 
     // PP: this is hacky -- we want the waveform to look like all signals
     // except the CLK has toggled. We temporarily set the CLK signal

--- a/pymtl3/passes/backends/verilog/tbgen/test/VerilogTBGenPass_test.py
+++ b/pymtl3/passes/backends/verilog/tbgen/test/VerilogTBGenPass_test.py
@@ -39,7 +39,7 @@ def test_normal_queue( do_test ):
     if tv[2] != '*': assert m.enq_rdy == tv[2]
     if tv[4] != '*': assert m.deq_rdy == tv[5]
     if tv[5] != '*': assert m.deq_msg == tv[4]
-  class VQueue( Component, Placeholder ):
+  class VQueueWithPorts( Component, Placeholder ):
     def construct( s, data_width, num_entries, count_width ):
       s.count   =  OutPort( mk_bits( count_width )  )
       s.deq_en  =  InPort( Bits1  )
@@ -49,9 +49,10 @@ def test_normal_queue( do_test ):
       s.enq_rdy = OutPort( Bits1  )
       s.enq_msg =  InPort( mk_bits( data_width ) )
       s.set_metadata( VerilogPlaceholderPass.src_file, dirname(__file__)+'/VQueue.v' )
+      s.set_metadata( VerilogPlaceholderPass.top_module, 'VQueue' )
       s.set_metadata( VerilogTranslationImportPass.enable, True )
   num_entries = 1
-  q = VQueue(
+  q = VQueueWithPorts(
       data_width = 32,
       num_entries = num_entries,
       count_width = clog2(num_entries+1))

--- a/pymtl3/passes/backends/verilog/test/TranslationImport_dynlib_close_test.py
+++ b/pymtl3/passes/backends/verilog/test/TranslationImport_dynlib_close_test.py
@@ -23,55 +23,53 @@ def run_test( _m ):
   sim.run_test()
 
 def test_dynlib_close():
-  class Comb:
-    class A( Component ):
-      def construct( s ):
-        s.in_ = InPort( Bits32 )
-        s.out = OutPort( Bits32 )
-        @update
-        def upblk():
-          s.out @= s.in_
-  class Seq:
-    class A( Component ):
-      def construct( s ):
-        s.in_ = InPort( Bits32 )
-        s.out = OutPort( Bits32 )
-        @update_ff
-        def upblk():
-          s.out <<= s.in_
+  class TestDynlibCloseComb( Component ):
+    def construct( s ):
+      s.in_ = InPort( Bits32 )
+      s.out = OutPort( Bits32 )
+      @update
+      def upblk():
+        s.out @= s.in_
+  class TestDynlibCloseSeq( Component ):
+    def construct( s ):
+      s.in_ = InPort( Bits32 )
+      s.out = OutPort( Bits32 )
+      @update_ff
+      def upblk():
+        s.out <<= s.in_
 
-  comb_a = Comb.A()
+  comb = TestDynlibCloseComb()
   # TestVectorSimulator properties
   def tv_in( m, tv ):
     m.in_ @= Bits32(tv[0])
   def tv_out( m, tv ):
     assert m.out == Bits32(tv[1])
-  comb_a._tvs = [
+  comb._tvs = [
     [    1,   1  ],
     [   42,   42 ],
     [   24,   24 ],
     [   -2,   -2 ],
     [   -1,   -1 ],
   ]
-  comb_a._tv_in, comb_a._tv_out = tv_in, tv_out
-  run_test( comb_a )
-  comb_hash = get_file_hash('A_noparam.verilator1.vcd')
+  comb._tv_in, comb._tv_out = tv_in, tv_out
+  run_test( comb )
+  comb_hash = get_file_hash('TestDynlibCloseComb_noparam.verilator1.vcd')
 
-  seq_a = Seq.A()
+  seq = TestDynlibCloseSeq()
   def tv_in( m, tv ):
     m.in_ @= Bits32(tv[0])
   def tv_out( m, tv ):
     if tv[1] != '*':
       assert m.out == Bits32(tv[1])
-  seq_a._tvs = [
+  seq._tvs = [
     [    1,   '*' ],
     [   42,    1  ],
     [   24,    42 ],
     [   -2,    24 ],
     [   -1,    -2 ],
   ]
-  seq_a._tv_in, seq_a._tv_out = tv_in, tv_out
-  run_test( seq_a )
-  seq_hash = get_file_hash('A_noparam.verilator1.vcd')
+  seq._tv_in, seq._tv_out = tv_in, tv_out
+  run_test( seq )
+  seq_hash = get_file_hash('TestDynlibCloseSeq_noparam.verilator1.vcd')
 
   assert comb_hash != seq_hash

--- a/pymtl3/passes/backends/verilog/testcases/test_cases.py
+++ b/pymtl3/passes/backends/verilog/testcases/test_cases.py
@@ -128,7 +128,7 @@ class CasePlaceholderTranslationVReg:
   ]
 
 class CasePlaceholderTranslationRegIncr:
-  class DUT( Component ):
+  class PlaceholderTranslationRegIncr( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits32 )
@@ -147,9 +147,10 @@ class CasePlaceholderTranslationRegIncr:
       [ -1, 43 ],
       [  0,  0 ],
   ]
+  DUT = PlaceholderTranslationRegIncr
 
 class CaseVIncludePopulation:
-  class DUT( Component ):
+  class VIncludePopulation( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits32 )
@@ -168,9 +169,10 @@ class CaseVIncludePopulation:
       [ -1, 42 ],
       [  0, -1 ],
   ]
+  DUT = VIncludePopulation
 
 class CaseVLibsTranslation:
-  class DUT( VerilogPlaceholder, Component ):
+  class VLibsTranslation( VerilogPlaceholder, Component ):
     def construct( s ):
       s.d = InPort( Bits32 )
       s.q = OutPort( Bits32 )
@@ -189,9 +191,10 @@ class CaseVLibsTranslation:
       [ -1, 42 ],
       [  0, -1 ],
   ]
+  DUT = VLibsTranslation
 
 class CaseMultiPlaceholderImport:
-  class DUT( Component ):
+  class MultiPlaceholderImport( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits32 )
@@ -211,27 +214,7 @@ class CaseMultiPlaceholderImport:
       [  0, 42 ],
       [  0, -1 ],
   ]
-
-class CasePlaceholderTranslationRegIncr:
-  class DUT( Component ):
-    def construct( s ):
-      s.in_ = InPort( Bits32 )
-      s.out = OutPort( Bits32 )
-      s.reg_ = Bits32VRegComp()
-      s.reg_.d //= s.in_
-      s.out //= lambda: s.reg_.q + Bits32(1)
-  TV_IN = \
-  _set( 'in_', Bits32, 0 )
-  TV_OUT = \
-  _check( 'out', Bits32, 1 )
-  TV = \
-  [
-      [  1,  1 ],
-      [  2,  2 ],
-      [ 42,  3 ],
-      [ -1, 43 ],
-      [  0,  0 ],
-  ]
+  DUT = MultiPlaceholderImport
 
 CaseSizeCastPaddingStructPort = set_attributes( CaseSizeCastPaddingStructPort,
     'REF_UPBLK',
@@ -246,7 +229,7 @@ CaseSizeCastPaddingStructPort = set_attributes( CaseSizeCastPaddingStructPort,
           logic [31:0] foo;
         } Bits32Foo__foo_32;
 
-        module DUT_noparam
+        module SizeCastPaddingStructPort_noparam
         (
           input logic [0:0] clk,
           input Bits32Foo__foo_32 in_,
@@ -271,7 +254,7 @@ CasePassThroughComp = set_attributes( CasePassThroughComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module PassThroughComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_,
@@ -296,7 +279,7 @@ CaseSequentialPassThroughComp = set_attributes( CaseSequentialPassThroughComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module SequentialPassThroughComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_,
@@ -329,7 +312,7 @@ CaseConnectPassThroughLongNameComp = set_attributes( CaseConnectPassThroughLongN
     ''',
     'REF_SRC',
     '''\
-        module DUT__2ae3b6d12e9855d1
+        module ConnectPassThroughLongNameComp__2ae3b6d12e9855d1
         (
           input logic [0:0] clk,
           input logic [31:0] in_,
@@ -355,7 +338,7 @@ CaseLambdaConnectComp = set_attributes( CaseLambdaConnectComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module LambdaConnectComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_,
@@ -380,7 +363,7 @@ CaseLambdaConnectWithListComp = set_attributes( CaseLambdaConnectWithListComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module LambdaConnectWithListComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_,
@@ -405,7 +388,7 @@ CaseBits32x2ConcatComp = set_attributes( CaseBits32x2ConcatComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module Bits32x2ConcatComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_1,
@@ -431,7 +414,7 @@ CaseBits32x2ConcatConstComp = set_attributes( CaseBits32x2ConcatConstComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module Bits32x2ConcatConstComp_noparam
         (
           input logic [0:0] clk,
           output logic [63:0] out,
@@ -455,7 +438,7 @@ CaseBits32x2ConcatMixedComp = set_attributes( CaseBits32x2ConcatMixedComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module Bits32x2ConcatMixedComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_,
@@ -480,7 +463,7 @@ CaseBits64SextInComp = set_attributes( CaseBits64SextInComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module Bits64SextInComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_,
@@ -505,7 +488,7 @@ CaseBits64ZextInComp = set_attributes( CaseBits64ZextInComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module Bits64ZextInComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_,
@@ -534,7 +517,7 @@ CaseBits64TruncInComp = set_attributes( CaseBits64TruncInComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module Bits64TruncInComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_,
@@ -559,7 +542,7 @@ CaseBits32x2ConcatFreeVarComp = set_attributes( CaseBits32x2ConcatFreeVarComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module Bits32x2ConcatFreeVarComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_,
@@ -585,7 +568,7 @@ CaseBits32x2ConcatUnpackedSignalComp = set_attributes( CaseBits32x2ConcatUnpacke
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module Bits32x2ConcatUnpackedSignalComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_ [0:1],
@@ -610,7 +593,7 @@ CaseBits32BitSelUpblkComp = set_attributes( CaseBits32BitSelUpblkComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module Bits32BitSelUpblkComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_,
@@ -635,7 +618,7 @@ CaseBits64PartSelUpblkComp = set_attributes( CaseBits64PartSelUpblkComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module Bits64PartSelUpblkComp_noparam
         (
           input logic [0:0] clk,
           input logic [63:0] in_,
@@ -672,7 +655,7 @@ CaseStructUnique = set_attributes( CaseStructUnique,
           logic [31:0] b_bar;
         } ST__b_foo_16__b_bar_32;
 
-        module DUT_noparam
+        module StructUnique_noparam
         (
           input logic [0:0] clk,
           output logic [31:0] out,
@@ -702,7 +685,7 @@ CasePythonClassAttr = set_attributes( CasePythonClassAttr,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module PythonClassAttr_noparam
         (
           input logic [0:0] clk,
           output logic [31:0] out1,
@@ -734,7 +717,7 @@ CaseTypeBundle = set_attributes( CaseTypeBundle,
           logic [31:0] foo;
         } Bits32Foo__foo_32;
 
-        module DUT_noparam
+        module TypeBundle_noparam
         (
           input logic [0:0] clk,
           output logic [31:0] out1,
@@ -765,7 +748,7 @@ CaseTmpVarInUpdateffComp = set_attributes( CaseTmpVarInUpdateffComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module TmpVarInUpdateffComp_noparam
         (
           input logic [0:0] clk,
           output logic [31:0] out,
@@ -799,7 +782,7 @@ CaseBoolTmpVarComp = set_attributes( CaseBoolTmpVarComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module BoolTmpVarComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_,
@@ -830,7 +813,7 @@ CaseDefaultBitsComp = set_attributes( CaseDefaultBitsComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module DefaultBitsComp_noparam
         (
           input logic [0:0] clk,
           output logic [31:0] out,
@@ -859,7 +842,7 @@ CaseBits32FooToBits32Comp = set_attributes( CaseBits32FooToBits32Comp,
           logic [31:0] foo;
         } Bits32Foo__foo_32;
 
-        module DUT_noparam
+        module Bits32FooToBits32Comp_noparam
         (
           input logic [0:0] clk,
           input Bits32Foo__foo_32 in_,
@@ -888,7 +871,7 @@ CaseBits32ToBits32FooComp = set_attributes( CaseBits32ToBits32FooComp,
           logic [31:0] foo;
         } Bits32Foo__foo_32;
 
-        module DUT_noparam
+        module Bits32ToBits32FooComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_,
@@ -917,7 +900,7 @@ CaseIntToBits32FooComp = set_attributes( CaseIntToBits32FooComp,
           logic [31:0] foo;
         } Bits32Foo__foo_32;
 
-        module DUT_noparam
+        module IntToBits32FooComp_noparam
         (
           input logic [0:0] clk,
           output Bits32Foo__foo_32 out,
@@ -941,7 +924,7 @@ CaseReducesInx3OutComp = set_attributes( CaseReducesInx3OutComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ReducesInx3OutComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_1,
@@ -972,7 +955,7 @@ CaseIfBasicComp = set_attributes( CaseIfBasicComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module IfBasicComp_noparam
         (
           input logic [0:0] clk,
           input logic [15:0] in_,
@@ -1007,7 +990,7 @@ CaseIfDanglingElseInnerComp = set_attributes( CaseIfDanglingElseInnerComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module IfDanglingElseInnerComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_1,
@@ -1045,7 +1028,7 @@ CaseIfDanglingElseOutterComp = set_attributes( CaseIfDanglingElseOutterComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module IfDanglingElseOutterComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_1,
@@ -1084,7 +1067,7 @@ CaseElifBranchComp = set_attributes( CaseElifBranchComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ElifBranchComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_1,
@@ -1136,7 +1119,7 @@ CaseNestedIfComp = set_attributes( CaseNestedIfComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module NestedIfComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_1,
@@ -1183,7 +1166,7 @@ CaseForLoopEmptySequenceComp = set_attributes( CaseForLoopEmptySequenceComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ForLoopEmptySequenceComp_noparam
         (
           input logic [0:0] clk,
           output logic [3:0] out,
@@ -1212,7 +1195,7 @@ CaseForRangeLowerUpperStepPassThroughComp = set_attributes( CaseForRangeLowerUpp
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ForRangeLowerUpperStepPassThroughComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_ [0:4],
@@ -1240,7 +1223,7 @@ CaseIfExpBothImplicitComp = set_attributes( CaseIfExpBothImplicitComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module IfExpBothImplicitComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_,
@@ -1266,7 +1249,7 @@ CaseIfExpInForStmtComp = set_attributes( CaseIfExpInForStmtComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module IfExpInForStmtComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_ [0:4],
@@ -1293,7 +1276,7 @@ CaseIfExpUnaryOpInForStmtComp = set_attributes( CaseIfExpUnaryOpInForStmtComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module IfExpUnaryOpInForStmtComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_ [0:4],
@@ -1324,7 +1307,7 @@ CaseIfBoolOpInForStmtComp = set_attributes( CaseIfBoolOpInForStmtComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module IfBoolOpInForStmtComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_ [0:4],
@@ -1361,7 +1344,7 @@ CaseIfTmpVarInForStmtComp = set_attributes( CaseIfTmpVarInForStmtComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module IfTmpVarInForStmtComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_ [0:4],
@@ -1394,7 +1377,7 @@ CaseInterfaceArrayNonStaticIndexComp = set_attributes( CaseInterfaceArrayNonStat
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module InterfaceArrayNonStaticIndexComp_noparam
         (
           input logic [0:0] clk,
           output logic [31:0] out,
@@ -1420,7 +1403,7 @@ CaseFixedSizeSliceComp = set_attributes( CaseFixedSizeSliceComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module FixedSizeSliceComp_noparam
         (
           input logic [0:0] clk,
           input logic [15:0] in_,
@@ -1450,7 +1433,7 @@ CaseBits32FooInBits32OutComp = set_attributes( CaseBits32FooInBits32OutComp,
           logic [31:0] foo;
         } Bits32Foo__foo_32;
 
-        module DUT_noparam
+        module Bits32FooInBits32OutComp_noparam
         (
           input logic [0:0] clk,
           input Bits32Foo__foo_32 in_,
@@ -1475,7 +1458,7 @@ CaseConstStructInstComp = set_attributes( CaseConstStructInstComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ConstStructInstComp_noparam
         (
           input logic [0:0] clk,
           output logic [31:0] out,
@@ -1503,7 +1486,7 @@ CaseStructPackedArrayUpblkComp = set_attributes( CaseStructPackedArrayUpblkComp,
           logic [4:0][31:0] foo;
         } Bits32x5Foo__foo_32x5;
 
-        module DUT_noparam
+        module StructPackedArrayUpblkComp_noparam
         (
           input logic [0:0] clk,
           input Bits32x5Foo__foo_32x5 in_,
@@ -1538,7 +1521,7 @@ CaseNestedStructPackedArrayUpblkComp = set_attributes( CaseNestedStructPackedArr
           Bits32Foo__foo_32 woo;
         } NestedStructPackedPlusScalar__c467caf2a4dfbfb2;
 
-        module DUT_noparam
+        module NestedStructPackedArrayUpblkComp_noparam
         (
           input logic [0:0] clk,
           input NestedStructPackedPlusScalar__c467caf2a4dfbfb2 in_,
@@ -1565,7 +1548,7 @@ CaseConnectValRdyIfcUpblkComp = set_attributes( CaseConnectValRdyIfcUpblkComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ConnectValRdyIfcUpblkComp_noparam
         (
           input logic [0:0] clk,
           input logic [0:0] reset,
@@ -1596,7 +1579,7 @@ CaseArrayBits32IfcInUpblkComp = set_attributes( CaseArrayBits32IfcInUpblkComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ArrayBits32IfcInUpblkComp_noparam
         (
           input logic [0:0] clk,
           output logic [31:0] out,
@@ -1632,7 +1615,7 @@ CaseBits32SubCompAttrUpblkComp = set_attributes( CaseBits32SubCompAttrUpblkComp,
 
         endmodule
 
-        module DUT_noparam
+        module Bits32SubCompAttrUpblkComp_noparam
         (
           input logic [0:0] clk,
           output logic [31:0] out,
@@ -1680,7 +1663,7 @@ CaseBits32ArraySubCompAttrUpblkComp = set_attributes( CaseBits32ArraySubCompAttr
 
         endmodule
 
-        module DUT_noparam
+        module Bits32ArraySubCompAttrUpblkComp_noparam
         (
           input logic [0:0] clk,
           output logic [31:0] out,
@@ -1770,7 +1753,7 @@ CaseConnectInToWireComp = set_attributes( CaseConnectInToWireComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ConnectInToWireComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_ [0:4],
@@ -1807,7 +1790,7 @@ CaseConnectBitsConstToOutComp = set_attributes( CaseConnectBitsConstToOutComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ConnectBitsConstToOutComp_noparam
         (
           input logic [0:0] clk,
           output logic [31:0] out,
@@ -1840,7 +1823,7 @@ CaseConnectConstToOutComp = set_attributes( CaseConnectConstToOutComp,
     'REF_SRC',
     # const_ is not used in upblks so will be optimized away
     '''\
-        module DUT_noparam
+        module ConnectConstToOutComp_noparam
         (
           input logic [0:0] clk,
           output logic [31:0] out,
@@ -1871,7 +1854,7 @@ CaseConnectBitSelToOutComp = set_attributes( CaseConnectBitSelToOutComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ConnectBitSelToOutComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_,
@@ -1903,7 +1886,7 @@ CaseConnectSliceToOutComp = set_attributes( CaseConnectSliceToOutComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ConnectSliceToOutComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_,
@@ -1935,7 +1918,7 @@ CaseBitSelOverBitSelComp = set_attributes( CaseBitSelOverBitSelComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module BitSelOverBitSelComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_,
@@ -1967,7 +1950,7 @@ CaseBitSelOverPartSelComp = set_attributes( CaseBitSelOverPartSelComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module BitSelOverPartSelComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_,
@@ -1999,7 +1982,7 @@ CasePartSelOverBitSelComp = set_attributes( CasePartSelOverBitSelComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module PartSelOverBitSelComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_,
@@ -2031,7 +2014,7 @@ CasePartSelOverPartSelComp = set_attributes( CasePartSelOverPartSelComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module PartSelOverPartSelComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_,
@@ -2071,7 +2054,7 @@ CaseConnectConstStructAttrToOutComp = set_attributes( CaseConnectConstStructAttr
     # struct definition will be eliminated because it's not used
     # in an upblk
     '''\
-        module DUT_noparam
+        module ConnectConstStructAttrToOutComp_noparam
         (
           input logic [0:0] clk,
           output logic [31:0] out,
@@ -2124,7 +2107,7 @@ CaseConnectLiteralStructComp = set_attributes( CaseConnectLiteralStructComp,
           Bits32Foo__foo_32 woo;
         } NestedStructPackedPlusScalar__c467caf2a4dfbfb2;
 
-        module DUT_noparam
+        module ConnectLiteralStructComp_noparam
         (
           input logic [0:0] clk,
           output NestedStructPackedPlusScalar__c467caf2a4dfbfb2 out,
@@ -2166,7 +2149,7 @@ CaseConnectArrayStructAttrToOutComp = set_attributes( CaseConnectArrayStructAttr
           logic [4:0][31:0] foo;
         } Bits32x5Foo__foo_32x5;
 
-        module DUT_noparam
+        module ConnectArrayStructAttrToOutComp_noparam
         (
           input logic [0:0] clk,
           input Bits32x5Foo__foo_32x5 in_,
@@ -2223,7 +2206,7 @@ CaseConnectNestedStructPackedArrayComp = set_attributes( CaseConnectNestedStruct
           Bits32Foo__foo_32 woo;
         } NestedStructPackedPlusScalar__c467caf2a4dfbfb2;
 
-        module DUT_noparam
+        module ConnectNestedStructPackedArrayComp_noparam
         (
           input logic [0:0] clk,
           input NestedStructPackedPlusScalar__c467caf2a4dfbfb2 in_,
@@ -2257,7 +2240,7 @@ CaseConnectValRdyIfcComp = set_attributes( CaseConnectValRdyIfcComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ConnectValRdyIfcComp_noparam
         (
           input logic [0:0] clk,
           input logic [0:0] reset,
@@ -2294,7 +2277,7 @@ CaseConnectArrayBits32FooIfcComp = set_attributes( CaseConnectArrayBits32FooIfcC
           logic [31:0] foo;
         } Bits32Foo__foo_32;
 
-        module DUT_noparam
+        module ConnectArrayBits32FooIfcComp_noparam
         (
           input logic [0:0] clk,
           input logic [0:0] reset,
@@ -2335,7 +2318,7 @@ CaseConnectArrayNestedIfcComp = set_attributes( CaseConnectArrayNestedIfcComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ConnectArrayNestedIfcComp_noparam
         (
           input logic [0:0] clk,
           input logic [0:0] reset,
@@ -2389,7 +2372,7 @@ CaseBits32ConnectSubCompAttrComp = set_attributes( CaseBits32ConnectSubCompAttrC
 
         endmodule
 
-        module DUT_noparam
+        module Bits32ConnectSubCompAttrComp_noparam
         (
           input logic [0:0] clk,
           output logic [31:0] out,
@@ -2448,7 +2431,7 @@ CaseConnectArraySubCompArrayStructIfcComp = set_attributes( CaseConnectArraySubC
 
         endmodule
 
-        module DUT_noparam
+        module ConnectArraySubCompArrayStructIfcComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_,
@@ -2533,7 +2516,7 @@ CaseBits32ArrayConnectSubCompAttrComp = set_attributes( CaseBits32ArrayConnectSu
 
         endmodule
 
-        module DUT_noparam
+        module Bits32ArrayConnectSubCompAttrComp_noparam
         (
           input logic [0:0] clk,
           output logic [31:0] out,
@@ -2758,7 +2741,7 @@ CaseHeteroCompArrayComp = set_attributes( CaseHeteroCompArrayComp,
           end
         endmodule
 
-        module DUT_noparam
+        module HeteroCompArrayComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_1,
@@ -2845,7 +2828,7 @@ CaseBehavioralArraySubCompArrayStructIfcComp = set_attributes( CaseBehavioralArr
 
         endmodule
 
-        module DUT_noparam
+        module BehavioralArraySubCompArrayStructIfcComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_,
@@ -2902,7 +2885,7 @@ CaseBits32FooNoArgBehavioralComp = set_attributes( CaseBits32FooNoArgBehavioralC
           logic [31:0] foo ;
         } Bits32Foo__foo_32;
 
-        module DUT_noparam
+        module Bits32FooNoArgBehavioralComp_noparam
         (
           input logic [0:0] clk,
           output Bits32Foo__foo_32 out,

--- a/pymtl3/passes/backends/yosys/test/TranslationImport_adhoc_test.py
+++ b/pymtl3/passes/backends/yosys/test/TranslationImport_adhoc_test.py
@@ -40,10 +40,14 @@ from ..translation.structural.test.YosysStructuralTranslatorL4_test import (
 from ..YosysTranslationImportPass import YosysTranslationImportPass
 
 XFAILED_TESTS = [
-    # incoherent translation result of Yosys backend
+    # Incoherent translation result of Yosys backend
     # the translated design is correct after minor transformation
     # in logic synthesis, but verilator simulation is incorrect
     'CaseConnectLiteralStructComp',
+    # Negative-positive MULTIDRIVEN warning from Verilator: the translated
+    # module is functionally correct and the reported multiple drivers
+    # are actually the same signal.
+    'CaseConnectArrayBits32FooIfcComp',
 ]
 
 def run_test( case ):

--- a/pymtl3/passes/backends/yosys/testcases/test_cases.py
+++ b/pymtl3/passes/backends/yosys/testcases/test_cases.py
@@ -89,7 +89,7 @@ CaseSizeCastPaddingStructPort = set_attributes( CaseSizeCastPaddingStructPort,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module SizeCastPaddingStructPort_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in___foo,
@@ -117,7 +117,7 @@ CaseLambdaConnectWithListComp = set_attributes( CaseLambdaConnectWithListComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module LambdaConnectWithListComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_,
@@ -147,7 +147,7 @@ CaseBits32x2ConcatFreeVarComp = set_attributes( CaseBits32x2ConcatFreeVarComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module Bits32x2ConcatFreeVarComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_,
@@ -166,7 +166,7 @@ CaseBits32x2ConcatFreeVarComp = set_attributes( CaseBits32x2ConcatFreeVarComp,
 CaseBits32x2ConcatUnpackedSignalComp = set_attributes( CaseBits32x2ConcatUnpackedSignalComp,
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module Bits32x2ConcatUnpackedSignalComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in___0,
@@ -190,7 +190,7 @@ CaseBits32x2ConcatUnpackedSignalComp = set_attributes( CaseBits32x2ConcatUnpacke
 CaseConnectConstToOutComp = set_attributes( CaseConnectConstToOutComp,
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ConnectConstToOutComp_noparam
         (
           input logic [0:0] clk,
           output logic [31:0] out,
@@ -217,7 +217,7 @@ CaseForRangeLowerUpperStepPassThroughComp = set_attributes( CaseForRangeLowerUpp
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ForRangeLowerUpperStepPassThroughComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in___0,
@@ -271,7 +271,7 @@ CaseIfExpInForStmtComp = set_attributes( CaseIfExpInForStmtComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module IfExpInForStmtComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in___0,
@@ -314,7 +314,7 @@ CaseIfExpInForStmtComp = set_attributes( CaseIfExpInForStmtComp,
 CaseIfExpUnaryOpInForStmtComp = set_attributes( CaseIfExpUnaryOpInForStmtComp,
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module IfExpUnaryOpInForStmtComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in___0,
@@ -370,7 +370,7 @@ CaseIfBoolOpInForStmtComp = set_attributes( CaseIfBoolOpInForStmtComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module IfBoolOpInForStmtComp_noparam
         (
           input  logic [0:0]    clk,
           input  logic [31:0]   in___0,
@@ -434,7 +434,7 @@ CaseIfTmpVarInForStmtComp = set_attributes( CaseIfTmpVarInForStmtComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module IfTmpVarInForStmtComp_noparam
         (
           input  logic [0:0]    clk,
           input  logic [31:0]   in___0,
@@ -497,7 +497,7 @@ CaseFixedSizeSliceComp = set_attributes( CaseFixedSizeSliceComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module FixedSizeSliceComp_noparam
         (
           input  logic [0:0]    clk,
           input  logic [15:0]   in_,
@@ -532,7 +532,7 @@ CaseBits32FooInBits32OutComp = set_attributes( CaseBits32FooInBits32OutComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module Bits32FooInBits32OutComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in___foo,
@@ -560,7 +560,7 @@ CaseConstStructInstComp = set_attributes( CaseConstStructInstComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ConstStructInstComp_noparam
         (
           input  logic [0:0]    clk,
           output logic [31:0]   out,
@@ -584,7 +584,7 @@ CaseStructPackedArrayUpblkComp = set_attributes( CaseStructPackedArrayUpblkComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module StructPackedArrayUpblkComp_noparam
         (
           input  logic [0:0]    clk,
           input  logic [31:0]   in___foo__0,
@@ -628,7 +628,7 @@ CaseNestedStructPackedArrayUpblkComp = set_attributes( CaseNestedStructPackedArr
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module NestedStructPackedArrayUpblkComp_noparam
         (
           input  logic [0:0]    clk,
           input  logic [31:0]   in___foo,
@@ -669,7 +669,7 @@ CaseArrayBits32IfcInUpblkComp = set_attributes( CaseArrayBits32IfcInUpblkComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ArrayBits32IfcInUpblkComp_noparam
         (
           input  logic [0:0]    clk,
           output logic [31:0]   out,
@@ -707,7 +707,7 @@ CaseInterfaceArrayNonStaticIndexComp = set_attributes( CaseInterfaceArrayNonStat
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module InterfaceArrayNonStaticIndexComp_noparam
         (
           input  logic [0:0]    clk,
           output logic [31:0]   out,
@@ -751,7 +751,7 @@ CaseBits32ArraySubCompAttrUpblkComp = set_attributes( CaseBits32ArraySubCompAttr
 
         endmodule
 
-        module DUT_noparam
+        module Bits32ArraySubCompAttrUpblkComp_noparam
         (
           input  logic [0:0]    clk,
           output logic [31:0]   out,
@@ -894,7 +894,7 @@ CaseConnectInToWireComp = set_attributes( CaseConnectInToWireComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ConnectInToWireComp_noparam
         (
           input  logic [0:0]    clk,
           input  logic [31:0]   in___0,
@@ -950,7 +950,7 @@ CaseConnectBitsConstToOutComp = set_attributes( CaseConnectBitsConstToOutComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ConnectBitsConstToOutComp_noparam
         (
           input  logic [0:0]    clk,
           output logic [31:0]   out,
@@ -986,7 +986,7 @@ CaseConnectConstToOutComp = set_attributes( CaseConnectConstToOutComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ConnectConstToOutComp_noparam
         (
           input  logic [0:0]    clk,
           output logic [31:0]   out,
@@ -1023,7 +1023,7 @@ CaseConnectBitSelToOutComp = set_attributes( CaseConnectBitSelToOutComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ConnectBitSelToOutComp_noparam
         (
           input  logic [0:0]    clk,
           input  logic [31:0]   in_,
@@ -1061,7 +1061,7 @@ CaseConnectSliceToOutComp = set_attributes( CaseConnectSliceToOutComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ConnectSliceToOutComp_noparam
         (
           input  logic [0:0]    clk,
           input  logic [31:0]   in_,
@@ -1098,7 +1098,7 @@ CaseConnectConstStructAttrToOutComp = set_attributes( CaseConnectConstStructAttr
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ConnectConstStructAttrToOutComp_noparam
         (
           input  logic [0:0]    clk,
           output logic [31:0]   out,
@@ -1147,7 +1147,7 @@ CaseConnectLiteralStructComp = set_attributes( CaseConnectLiteralStructComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ConnectLiteralStructComp_noparam
         (
           input  logic [0:0]    clk,
           output logic [31:0]   out__foo,
@@ -1214,7 +1214,7 @@ CaseConnectArrayStructAttrToOutComp = set_attributes( CaseConnectArrayStructAttr
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ConnectArrayStructAttrToOutComp_noparam
         (
           input  logic [0:0]    clk,
           input  logic [31:0]   in___foo__0,
@@ -1284,7 +1284,7 @@ CaseConnectNestedStructPackedArrayComp = set_attributes( CaseConnectNestedStruct
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ConnectNestedStructPackedArrayComp_noparam
         (
           input  logic [0:0]    clk,
           input  logic [31:0]   in___foo,
@@ -1395,7 +1395,7 @@ CaseConnectValRdyIfcComp = set_attributes( CaseConnectValRdyIfcComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ConnectValRdyIfcComp_noparam
         (
           input  logic [0:0]    clk,
           input  logic [0:0]    reset,
@@ -1449,7 +1449,7 @@ CaseConnectArrayBits32FooIfcComp = set_attributes( CaseConnectArrayBits32FooIfcC
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ConnectArrayBits32FooIfcComp_noparam
         (
           input  logic [0:0]    clk,
           input  logic [0:0]    reset,
@@ -1543,7 +1543,7 @@ CaseConnectArrayNestedIfcComp = set_attributes( CaseConnectArrayNestedIfcComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module ConnectArrayNestedIfcComp_noparam
         (
           input  logic [0:0]    clk,
           input  logic [0:0]    reset,
@@ -1638,7 +1638,7 @@ CaseBits32ConnectSubCompAttrComp = set_attributes( CaseBits32ConnectSubCompAttrC
 
         endmodule
 
-        module DUT_noparam
+        module Bits32ConnectSubCompAttrComp_noparam
         (
           input  logic [0:0]    clk,
           output logic [31:0]   out,
@@ -1717,7 +1717,7 @@ CaseConnectArraySubCompArrayStructIfcComp = set_attributes( CaseConnectArraySubC
 
         endmodule
 
-        module DUT_noparam
+        module ConnectArraySubCompArrayStructIfcComp_noparam
         (
           input  logic [0:0]    clk,
           input  logic [31:0]   in_,
@@ -1858,7 +1858,7 @@ CaseBits32ArrayConnectSubCompAttrComp = set_attributes( CaseBits32ArrayConnectSu
 
         endmodule
 
-        module DUT_noparam
+        module Bits32ArrayConnectSubCompAttrComp_noparam
         (
           input  logic [0:0]    clk,
           output logic [31:0]   out,
@@ -1990,7 +1990,7 @@ CaseBehavioralArraySubCompArrayStructIfcComp = set_attributes( CaseBehavioralArr
 
         endmodule
 
-        module DUT_noparam
+        module BehavioralArraySubCompArrayStructIfcComp_noparam
         (
           input  logic [0:0]    clk,
           input  logic [31:0]   in_,
@@ -2070,7 +2070,7 @@ CaseTypeBundle = set_attributes( CaseTypeBundle,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module TypeBundle_noparam
         (
           input logic [0:0] clk,
           output logic [31:0] out1,
@@ -2104,7 +2104,7 @@ CaseBits32FooToBits32Comp = set_attributes( CaseBits32FooToBits32Comp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module Bits32FooToBits32Comp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in___foo,
@@ -2133,7 +2133,7 @@ CaseBits32ToBits32FooComp = set_attributes( CaseBits32ToBits32FooComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module Bits32ToBits32FooComp_noparam
         (
           input logic [0:0] clk,
           input logic [31:0] in_,
@@ -2162,7 +2162,7 @@ CaseIntToBits32FooComp = set_attributes( CaseIntToBits32FooComp,
     ''',
     'REF_SRC',
     '''\
-        module DUT_noparam
+        module IntToBits32FooComp_noparam
         (
           input logic [0:0] clk,
           output logic [31:0] out__foo,

--- a/pymtl3/passes/testcases/test_cases.py
+++ b/pymtl3/passes/testcases/test_cases.py
@@ -279,67 +279,79 @@ class TestCompExplicitModuleName( Component ):
 #-------------------------------------------------------------------------
 
 class CaseBits32PortOnly:
-  class DUT( Component ):
+  class Bits32PortOnly( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
+  DUT = Bits32PortOnly
 
 class CaseStructPortOnly:
-  class DUT( Component ):
+  class StructPortOnly( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
+  DUT = StructPortOnly
 
 class CaseNestedStructPortOnly:
-  class DUT( Component ):
+  class NestedStructPortOnly( Component ):
     def construct( s ):
       s.in_ = InPort( NestedBits32Foo )
+  DUT = NestedStructPortOnly
 
 class CasePackedArrayStructPortOnly:
-  class DUT( Component ):
+  class PackedArrayStructPortOnly( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32x5Foo )
+  DUT = PackedArrayStructPortOnly
 
 class CaseBits32x5PortOnly:
-  class DUT( Component ):
+  class Bits32x5PortOnly( Component ):
     def construct( s ):
       s.in_ = [ InPort( Bits32 ) for _ in range(5) ]
+  DUT = Bits32x5PortOnly
 
 class CaseBits32x5WireOnly:
-  class DUT( Component ):
+  class Bits32x5WireOnly( Component ):
     def construct( s ):
       s.in_ = [ Wire( Bits32 ) for _ in range(5) ]
+  DUT = Bits32x5WireOnly
 
 class CaseStructx5PortOnly:
-  class DUT( Component ):
+  class Structx5PortOnly( Component ):
     def construct( s ):
       s.in_ = [ InPort( Bits32Foo ) for _ in range(5) ]
+  DUT = Structx5PortOnly
 
 class CaseBits32x5ConstOnly:
-  class DUT( Component ):
+  class Bits32x5ConstOnly( Component ):
     def construct( s ):
       s.in_ = [ Bits32(42) for _ in range(5) ]
+  DUT = Bits32x5ConstOnly
 
 class CaseBits32MsgRdyIfcOnly:
-  class DUT( Component ):
+  class Bits32MsgRdyIfcOnly( Component ):
     def construct( s ):
       s.in_ = [ Bits32MsgRdyIfc() for _ in range(5) ]
+  DUT = Bits32MsgRdyIfcOnly
 
 class CaseBits32InOutx5CompOnly:
-  class DUT( Component ):
+  class Bits32InOutx5CompOnly( Component ):
     def construct( s ):
       s.b = [ Bits32InOutComp() for _ in range(5) ]
+  DUT = Bits32InOutx5CompOnly
 
 class CaseBits32Outx3x2x1PortOnly:
-  class DUT( Component ):
+  class Bits32Outx3x2x1PortOnly( Component ):
     def construct( s ):
       s.out = [[[OutPort(Bits32) for _ in range(1)] for _ in range(2)] for _ in range(3)]
+  DUT = Bits32Outx3x2x1PortOnly
 
 class CaseBits32WireIfcOnly:
-  class DUT( Component ):
+  class Bits32WireIfcOnly( Component ):
     def construct( s ):
       s.in_ = Bits32FooWireBarInIfc()
+  DUT = Bits32WireIfcOnly
 
 class CaseBits32ClosureConstruct:
-  class DUT( Component ):
+  class Bits32ClosureConstruct( Component ):
     def construct( s ):
       foo = Bits32( 42 )
       s.fvar_ref = foo
@@ -347,26 +359,29 @@ class CaseBits32ClosureConstruct:
       @update
       def upblk():
         s.out @= foo
+  DUT = Bits32ClosureConstruct
 
 class CaseBits32ArrayClosureConstruct:
-  class DUT( Component ):
+  class Bits32ArrayClosureConstruct( Component ):
     def construct( s ):
       foo = [ Bits32(42) for _ in range(5) ]
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= foo[2]
+  DUT = Bits32ArrayClosureConstruct
 
 class CaseBits32ClosureGlobal:
-  class DUT( Component ):
+  class Bits32ClosureGlobal( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= pymtl_Bits_global_freevar
+  DUT = Bits32ClosureGlobal
 
 class CaseStructClosureGlobal:
-  class DUT( Component ):
+  class StructClosureGlobal( Component ):
     def construct( s ):
       foo = InPort( Bits32Foo )
       s._foo = foo
@@ -374,9 +389,10 @@ class CaseStructClosureGlobal:
       @update
       def upblk():
         s.out @= foo.foo
+  DUT = StructClosureGlobal
 
 class CaseStructUnique:
-  class DUT( Component ):
+  class StructUnique( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       s.ST_A_wire = Wire( StructUniqueA.ST )
@@ -394,9 +410,10 @@ class CaseStructUnique:
       [ 6 ],
       [ 6 ],
   ]
+  DUT = StructUnique
 
 class CasePythonClassAttr:
-  class DUT( Component ):
+  class PythonClassAttr( Component ):
     def construct( s ):
       class Enum:
         int_attr = 42
@@ -418,9 +435,10 @@ class CasePythonClassAttr:
       [  42,   1,  ],
       [  42,   1,  ],
   ]
+  DUT = PythonClassAttr
 
 class CaseTypeBundle:
-  class DUT( Component ):
+  class TypeBundle( Component ):
     def construct( s ):
       class TypeBundle:
         BitsType = Bits32
@@ -445,9 +463,10 @@ class CaseTypeBundle:
       [  42,   1,  1, ],
       [  42,   1,  1, ],
   ]
+  DUT = TypeBundle
 
 class CaseBoolTmpVarComp:
-  class DUT( Component ):
+  class BoolTmpVarComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits32 )
@@ -472,9 +491,10 @@ class CaseBoolTmpVarComp:
       [  1,   0,  ],
       [  0,   1,  ],
   ]
+  DUT = BoolTmpVarComp
 
 class CaseTmpVarInUpdateffComp:
-  class DUT( Component ):
+  class TmpVarInUpdateffComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       @update_ff
@@ -493,9 +513,10 @@ class CaseTmpVarInUpdateffComp:
       [  42, ],
       [  42, ],
   ]
+  DUT = TmpVarInUpdateffComp
 
 class CaseBits32FooToBits32Comp:
-  class DUT( Component ):
+  class Bits32FooToBits32Comp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits32 )
@@ -516,9 +537,10 @@ class CaseBits32FooToBits32Comp:
       [   42,   42,  ],
       [  -42,  -42,  ],
   ]
+  DUT = Bits32FooToBits32Comp
 
 class CaseBits32ToBits32FooComp:
-  class DUT( Component ):
+  class Bits32ToBits32FooComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits32Foo )
@@ -539,9 +561,10 @@ class CaseBits32ToBits32FooComp:
       [   42,   42,  ],
       [  -42,  -42,  ],
   ]
+  DUT = Bits32ToBits32FooComp
 
 class CaseIntToBits32FooComp:
-  class DUT( Component ):
+  class IntToBits32FooComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32Foo )
       @update
@@ -558,9 +581,10 @@ class CaseIntToBits32FooComp:
       [ 42 ],
       [ 42 ],
   ]
+  DUT = IntToBits32FooComp
 
 class CaseReducesInx3OutComp:
-  class DUT( Component ):
+  class ReducesInx3OutComp( Component ):
     def construct( s ):
       s.in_1 = InPort( Bits32 )
       s.in_2 = InPort( Bits32 )
@@ -584,9 +608,10 @@ class CaseReducesInx3OutComp:
       [  9,   8,    7,  1   ],
       [  9,   8,    0,  0   ],
   ]
+  DUT = ReducesInx3OutComp
 
 class CaseBits16IndexBasicComp:
-  class DUT( Component ):
+  class Bits16IndexBasicComp( Component ):
     def construct( s ):
       s.in_ = [ InPort( Bits16 ) for _ in range( 4 ) ]
       s.out = [ OutPort( Bits16 ) for _ in range( 2 ) ]
@@ -594,18 +619,20 @@ class CaseBits16IndexBasicComp:
       def index_basic():
         s.out[ 0 ] @= s.in_[ 0 ] + s.in_[ 1 ]
         s.out[ 1 ] @= s.in_[ 2 ] + s.in_[ 3 ]
+  DUT = Bits16IndexBasicComp
 
 class CaseBits8Bits16MismatchAssignComp:
-  class DUT( Component ):
+  class Bits8Bits16MismatchAssignComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits16 )
       s.out = OutPort( Bits8 )
       @update
       def mismatch_width_assign():
         s.out @= s.in_
+  DUT = Bits8Bits16MismatchAssignComp
 
 class CaseBits32Bits64SlicingBasicComp:
-  class DUT( Component ):
+  class Bits32Bits64SlicingBasicComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits64 )
@@ -613,18 +640,20 @@ class CaseBits32Bits64SlicingBasicComp:
       def slicing_basic():
         s.out[ 0:16 ] @= s.in_[ 16:32 ]
         s.out[ 16:32 ] @= s.in_[ 0:16 ]
+  DUT = Bits32Bits64SlicingBasicComp
 
 class CaseBits16ConstAddComp:
-  class DUT( Component ):
+  class Bits16ConstAddComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits16 )
       s.out = OutPort( Bits16 )
       @update
       def bits_basic():
         s.out @= s.in_ + Bits16( 10 )
+  DUT = Bits16ConstAddComp
 
 class CaseSlicingOverIndexComp:
-  class DUT( Component ):
+  class SlicingOverIndexComp( Component ):
     def construct( s ):
       s.in_ = [ InPort( Bits16 ) for _ in range( 10 ) ]
       s.out = [ OutPort( Bits16 ) for _ in range( 5 ) ]
@@ -632,9 +661,10 @@ class CaseSlicingOverIndexComp:
       def index_bits_slicing():
         s.out[0][0:8] @= s.in_[1][8:16] + s.in_[2][0:8] + 10
         s.out[1] @= s.in_[3][0:16] + s.in_[4] + 1
+  DUT = SlicingOverIndexComp
 
 class CaseSubCompAddComp:
-  class DUT( Component ):
+  class SubCompAddComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits16 )
       s.out = OutPort( Bits16 )
@@ -644,9 +674,10 @@ class CaseSubCompAddComp:
       @update
       def multi_components_A():
         s.out @= s.in_ + s.b.out
+  DUT = SubCompAddComp
 
 class CaseIfBasicComp:
-  class DUT( Component ):
+  class IfBasicComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits16 )
       s.out = OutPort( Bits8 )
@@ -669,9 +700,10 @@ class CaseIfBasicComp:
       [  42,   0, ],
       [   0,   0, ],
   ]
+  DUT = IfBasicComp
 
 class CaseIfDanglingElseInnerComp:
-  class DUT( Component ):
+  class IfDanglingElseInnerComp( Component ):
     def construct( s ):
       s.in_1 = InPort( Bits32 )
       s.in_2 = InPort( Bits32 )
@@ -698,9 +730,10 @@ class CaseIfDanglingElseInnerComp:
       [   -2,    24,  24 ],
       [   -1,    -2,  -2 ],
   ]
+  DUT = IfDanglingElseInnerComp
 
 class CaseIfDanglingElseOutterComp:
-  class DUT( Component ):
+  class IfDanglingElseOutterComp( Component ):
     def construct( s ):
       s.in_1 = InPort( Bits32 )
       s.in_2 = InPort( Bits32 )
@@ -727,9 +760,10 @@ class CaseIfDanglingElseOutterComp:
       [   -2,    24,   0 ],
       [   -1,    -2,   0 ],
   ]
+  DUT = IfDanglingElseOutterComp
 
 class CaseElifBranchComp:
-  class DUT( Component ):
+  class ElifBranchComp( Component ):
     def construct( s ):
       s.in_1 = InPort( Bits32 )
       s.in_2 = InPort( Bits32 )
@@ -759,9 +793,10 @@ class CaseElifBranchComp:
       [   -2,    24,  -2, -2 ],
       [   -1,    -2,  -1, -1 ],
   ]
+  DUT = ElifBranchComp
 
 class CaseNestedIfComp:
-  class DUT( Component ):
+  class NestedIfComp( Component ):
     def construct( s ):
       s.in_1 = InPort( Bits32 )
       s.in_2 = InPort( Bits32 )
@@ -800,9 +835,10 @@ class CaseNestedIfComp:
       [   -2,    24,  -2,  24 ],
       [   -1,    -2,  -1,  -2 ],
   ]
+  DUT = NestedIfComp
 
 class CaseForBasicComp:
-  class DUT( Component ):
+  class ForBasicComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits16 )
       s.out = OutPort( Bits8 )
@@ -810,9 +846,10 @@ class CaseForBasicComp:
       def for_basic():
         for i in range( 8 ):
           s.out[ 2*i:2*i+1 ] @= s.in_[ 2*i:2*i+1 ] + s.in_[ 2*i+1:(2*i+1)+1 ]
+  DUT = ForBasicComp
 
 class CaseForFreeVarStepComp:
-  class DUT( Component ):
+  class ForFreeVarStepComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits16 )
       s.out = OutPort( Bits8 )
@@ -821,16 +858,18 @@ class CaseForFreeVarStepComp:
       def upblk():
         for i in range( 0, 2, freevar ):
           s.out @= s.in_[0:8]
+  DUT = ForFreeVarStepComp
 
 class CaseTypeNameAsFieldNameComp:
-  class DUT( Component ):
+  class TypeNameAsFieldNameComp( Component ):
     def construct( s ):
       s.in_ = InPort( StructTypeNameAsFieldName )
       s.out = OutPort( StructTypeNameAsFieldName )
       s.in_ //= s.out
+  DUT = TypeNameAsFieldNameComp
 
 class CaseForRangeLowerUpperStepPassThroughComp:
-  class DUT( Component ):
+  class ForRangeLowerUpperStepPassThroughComp( Component ):
     def construct( s ):
       s.in_ = [ InPort( Bits32 ) for _ in range(5) ]
       s.out = [ OutPort( Bits32 ) for _ in range(5) ]
@@ -864,9 +903,10 @@ class CaseForRangeLowerUpperStepPassThroughComp:
       [   -2,    24,  -2,  24,  -2,   -2,    24,  -2,  24,  -2, ],
       [   -1,    -2,  -1,  -2,  -1,   -1,    -2,  -1,  -2,  -1, ],
   ]
+  DUT = ForRangeLowerUpperStepPassThroughComp
 
 class CaseForLoopEmptySequenceComp:
-  class DUT( Component ):
+  class ForLoopEmptySequenceComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits4 )
       @update
@@ -881,9 +921,10 @@ class CaseForLoopEmptySequenceComp:
       [0xF],
       [0xF],
   ]
+  DUT = ForLoopEmptySequenceComp
 
 class CaseIfExpBothImplicitComp:
-  class DUT( Component ):
+  class IfExpBothImplicitComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits32 )
@@ -899,9 +940,10 @@ class CaseIfExpBothImplicitComp:
       [    1,    1, ],
       [    0,    0, ],
   ]
+  DUT = IfExpBothImplicitComp
 
 class CaseIfExpInForStmtComp:
-  class DUT( Component ):
+  class IfExpInForStmtComp( Component ):
     def construct( s ):
       s.in_ = [ InPort( Bits32 ) for _ in range(5) ]
       s.out = [ OutPort( Bits32 ) for _ in range(5) ]
@@ -933,9 +975,10 @@ class CaseIfExpInForStmtComp:
       [   -2,    24,  -2,  24,  -2,   -2,    24,  -2,  -2,  -2, ],
       [   -1,    -2,  -1,  -2,  -1,   -1,    -2,  -1,  -1,  -1, ],
   ]
+  DUT = IfExpInForStmtComp
 
 class CaseIfExpUnaryOpInForStmtComp:
-  class DUT( Component ):
+  class IfExpUnaryOpInForStmtComp( Component ):
     def construct( s ):
       s.in_ = [ InPort( Bits32 ) for _ in range(5) ]
       s.out = [ OutPort( Bits32 ) for _ in range(5) ]
@@ -967,9 +1010,10 @@ class CaseIfExpUnaryOpInForStmtComp:
       [   -2,    24,  -2,  24,  -2,   -2,    ~24,  -2,  -2,  -2, ],
       [   -1,    -2,  -1,  -2,  -1,   -1,    ~-2,  -1,  -1,  -1, ],
   ]
+  DUT = IfExpUnaryOpInForStmtComp
 
 class CaseIfBoolOpInForStmtComp:
-  class DUT( Component ):
+  class IfBoolOpInForStmtComp( Component ):
     def construct( s ):
       s.in_ = [ InPort( Bits32 ) for _ in range(5) ]
       s.out = [ OutPort( Bits32 ) for _ in range(5) ]
@@ -1004,9 +1048,10 @@ class CaseIfBoolOpInForStmtComp:
       [   -2,    24,  -2,  24,  -2,    -2,    24,   -2,   24,   -2, ],
       [   -1,    -2,  -1,  -2,  -1,    -1,    -2,   -1,   -2,   -1, ],
   ]
+  DUT = IfBoolOpInForStmtComp
 
 class CaseIfTmpVarInForStmtComp:
-  class DUT( Component ):
+  class IfTmpVarInForStmtComp( Component ):
     def construct( s ):
       s.in_ = [ InPort( Bits32 ) for _ in range(5) ]
       s.out = [ OutPort( Bits32 ) for _ in range(5) ]
@@ -1042,9 +1087,10 @@ class CaseIfTmpVarInForStmtComp:
     [   -2,    24,  -2,  24,  -2,    -2,    24,   -2,   24,   -2, ],
     [   -1,    -2,  -1,  -2,  -1,    -1,    -2,   -1,   -2,   -1, ],
   ]
+  DUT = IfTmpVarInForStmtComp
 
 class CaseFixedSizeSliceComp:
-  class DUT( Component ):
+  class FixedSizeSliceComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits16 )
       s.out = [ OutPort( Bits8 ) for _ in range(2) ]
@@ -1068,9 +1114,10 @@ class CaseFixedSizeSliceComp:
       [ 0x3412, 0x12, 0x34 ],
       [ 0x9876, 0x76, 0x98 ],
   ]
+  DUT = FixedSizeSliceComp
 
 class CaseTwoUpblksSliceComp:
-  class DUT( Component ):
+  class TwoUpblksSliceComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits4 )
       s.out = OutPort( Bits8 )
@@ -1080,9 +1127,10 @@ class CaseTwoUpblksSliceComp:
       @update
       def multi_upblks_2():
         s.out[ 4:8 ] @= s.in_
+  DUT = TwoUpblksSliceComp
 
 class CaseTwoUpblksFreevarsComp:
-  class DUT( Component ):
+  class TwoUpblksFreevarsComp( Component ):
     def construct( s ):
       STATE_IDLE = Bits2(0)
       STATE_WORK = Bits2(1)
@@ -1093,9 +1141,10 @@ class CaseTwoUpblksFreevarsComp:
       @update
       def multi_upblks_2():
         s.out[1] @= STATE_WORK
+  DUT = TwoUpblksFreevarsComp
 
 class CaseTwoUpblksStructTmpWireComp:
-  class DUT( Component ):
+  class TwoUpblksStructTmpWireComp( Component ):
     def construct( s ):
       s.in_foo = InPort( Bits32Foo )
       s.in_bar = InPort( Bits32Bar )
@@ -1109,9 +1158,10 @@ class CaseTwoUpblksStructTmpWireComp:
       def multi_upblks_2():
         u = s.in_bar
         s.out_bar @= u.bar
+  DUT = TwoUpblksStructTmpWireComp
 
 class CaseFlipFlopAdder:
-  class DUT( Component ):
+  class FlipFlopAdder( Component ):
     def construct( s ):
       s.in0 = InPort( Bits32 )
       s.in1 = InPort( Bits32 )
@@ -1119,9 +1169,10 @@ class CaseFlipFlopAdder:
       @update_ff
       def update_ff_upblk():
         s.out0 <<= s.in0 + s.in1
+  DUT = FlipFlopAdder
 
 class CaseConstSizeSlicingComp:
-  class DUT( Component ):
+  class ConstSizeSlicingComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits16 )
       s.out = [ OutPort( Bits8 ) for _ in range(2) ]
@@ -1129,9 +1180,10 @@ class CaseConstSizeSlicingComp:
       def upblk():
         for i in range(2):
           s.out[i] @= s.in_[i*8 : i*8 + 8]
+  DUT = ConstSizeSlicingComp
 
 class CaseBits32TmpWireComp:
-  class DUT( Component ):
+  class Bits32TmpWireComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits32 )
@@ -1139,9 +1191,10 @@ class CaseBits32TmpWireComp:
       def upblk():
         u = s.in_ + 42
         s.out @= u
+  DUT = Bits32TmpWireComp
 
 class CaseBits32MultiTmpWireComp:
-  class DUT( Component ):
+  class Bits32MultiTmpWireComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits32 )
@@ -1151,9 +1204,10 @@ class CaseBits32MultiTmpWireComp:
         v = s.in_ + 40
         s.out @= u
         s.out @= v
+  DUT = Bits32MultiTmpWireComp
 
 class CaseBits32FreeVarToTmpVarComp:
-  class DUT( Component ):
+  class Bits32FreeVarToTmpVarComp( Component ):
     def construct( s ):
       # STATE_IDLE = Bits32(0)
       s.out = OutPort( Bits32 )
@@ -1161,27 +1215,30 @@ class CaseBits32FreeVarToTmpVarComp:
       def upblk():
         u = STATE_IDLE
         s.out @= u
+  DUT = Bits32FreeVarToTmpVarComp
 
 class CaseBits32ConstBitsToTmpVarComp:
-  class DUT( Component ):
+  class Bits32ConstBitsToTmpVarComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         u = Bits32(0)
         s.out @= u
+  DUT = Bits32ConstBitsToTmpVarComp
 
 class CaseBits32ConstIntToTmpVarComp:
-  class DUT( Component ):
+  class Bits32ConstIntToTmpVarComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         u = 1
         s.out @= u
+  DUT = Bits32ConstIntToTmpVarComp
 
 class CaseBits32TmpWireAliasComp:
-  class DUT( Component ):
+  class Bits32TmpWireAliasComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = [ OutPort( Bits32 ) for _ in range(5) ]
@@ -1193,9 +1250,10 @@ class CaseBits32TmpWireAliasComp:
       def multi_upblks_2():
         u = s.in_ + 42
         s.out[1] @= u
+  DUT = Bits32TmpWireAliasComp
 
 class CaseStructTmpWireComp:
-  class DUT( Component ):
+  class StructTmpWireComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits32 )
@@ -1203,9 +1261,10 @@ class CaseStructTmpWireComp:
       def upblk():
         u = s.in_
         s.out @= u.foo
+  DUT = StructTmpWireComp
 
 class CaseTmpWireOverwriteConflictComp:
-  class DUT( Component ):
+  class TmpWireOverwriteConflictComp( Component ):
     def construct( s ):
       s.in_1 = InPort( Bits32 )
       s.in_2 = InPort( Bits16 )
@@ -1215,9 +1274,10 @@ class CaseTmpWireOverwriteConflictComp:
         u = s.in_1 + 42
         u = s.in_2 + 1
         s.out @= u
+  DUT = TmpWireOverwriteConflictComp
 
 class CaseScopeTmpWireOverwriteConflictComp:
-  class DUT( Component ):
+  class ScopeTmpWireOverwriteConflictComp( Component ):
     def construct( s ):
       s.in_1 = InPort( Bits32 )
       s.in_2 = InPort( Bits16 )
@@ -1230,9 +1290,10 @@ class CaseScopeTmpWireOverwriteConflictComp:
         else:
           u = s.in_2 + 1
           s.out @= u
+  DUT = ScopeTmpWireOverwriteConflictComp
 
 class CaseHeteroCompArrayComp:
-  class DUT( Component ):
+  class HeteroCompArrayComp( Component ):
     def construct( s ):
       s.in_1 = InPort( Bits32 )
       s.in_2 = InPort( Bits32 )
@@ -1260,9 +1321,10 @@ class CaseHeteroCompArrayComp:
       [   42,      0,    42,    42],
       [   -1,     42,    -1,    84],
   ]
+  DUT = HeteroCompArrayComp
 
 class CaseChildExplicitModuleName:
-  class DUT( Component ):
+  class ChildExplicitModuleName( Component ):
     def construct( s ):
       s.in_ = InPort( 32 )
       s.child = TestCompExplicitModuleName()
@@ -1273,13 +1335,14 @@ class CaseChildExplicitModuleName:
   [
       [ 0 ],
   ]
+  DUT = ChildExplicitModuleName
 
 #-------------------------------------------------------------------------
 # Test cases without errors
 #-------------------------------------------------------------------------
 
 class CaseSizeCastPaddingStructPort:
-  class DUT( Component ):
+  class SizeCastPaddingStructPort( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits64 )
@@ -1298,9 +1361,10 @@ class CaseSizeCastPaddingStructPort:
       [   42,     concat(   Bits32(0),     Bits32(42) ) ],
       [   -1,     concat(   Bits32(0),     Bits32(-1) ) ],
   ]
+  DUT = SizeCastPaddingStructPort
 
 class CaseBits32x2ConcatComp:
-  class DUT( Component ):
+  class Bits32x2ConcatComp( Component ):
     def construct( s ):
       s.in_1 = InPort( Bits32 )
       s.in_2 = InPort( Bits32 )
@@ -1322,9 +1386,10 @@ class CaseBits32x2ConcatComp:
       [   42,   42,     concat(   Bits32(42),    Bits32(42) ) ],
       [   -1,   42,     concat(   Bits32(-1),    Bits32(42) ) ],
   ]
+  DUT = Bits32x2ConcatComp
 
 class CaseBits32x2ConcatConstComp:
-  class DUT( Component ):
+  class Bits32x2ConcatConstComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits64 )
       @update
@@ -1338,9 +1403,10 @@ class CaseBits32x2ConcatConstComp:
   [
       [    concat(    Bits32(42),    Bits32(0) ) ],
   ]
+  DUT = Bits32x2ConcatConstComp
 
 class CaseBits32x2ConcatMixedComp:
-  class DUT( Component ):
+  class Bits32x2ConcatMixedComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits64 )
@@ -1358,9 +1424,10 @@ class CaseBits32x2ConcatMixedComp:
       [  -2,  concat(    Bits32(-2),    Bits32(0) ) ],
       [   2,  concat(     Bits32(2),    Bits32(0) ) ],
   ]
+  DUT = Bits32x2ConcatMixedComp
 
 class CaseBits32x2ConcatFreeVarComp:
-  class DUT( Component ):
+  class Bits32x2ConcatFreeVarComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits33 )
@@ -1378,9 +1445,10 @@ class CaseBits32x2ConcatFreeVarComp:
       [  -2,  concat(    Bits32(-2),    Bits1(0) ) ],
       [   2,  concat(     Bits32(2),    Bits1(0) ) ],
   ]
+  DUT = Bits32x2ConcatFreeVarComp
 
 class CaseBits32x2ConcatUnpackedSignalComp:
-  class DUT( Component ):
+  class Bits32x2ConcatUnpackedSignalComp( Component ):
     def construct( s ):
       s.in_ = [ InPort( Bits32 ) for _ in range(2) ]
       s.out = OutPort( Bits64 )
@@ -1401,9 +1469,10 @@ class CaseBits32x2ConcatUnpackedSignalComp:
       [  -2,  -1,  concat(    Bits32(-2),    Bits32(-1) ) ],
       [   2,  -2,  concat(     Bits32(2),    Bits32(-2) ) ],
   ]
+  DUT = Bits32x2ConcatUnpackedSignalComp
 
 class CaseBits64SextInComp:
-  class DUT( Component ):
+  class Bits64SextInComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits64 )
@@ -1421,9 +1490,10 @@ class CaseBits64SextInComp:
       [  -1,   sext(    Bits32(-1),    64 ) ],
       [   2,   sext(     Bits32(2),    64 ) ],
   ]
+  DUT = Bits64SextInComp
 
 class CaseBits64ZextInComp:
-  class DUT( Component ):
+  class Bits64ZextInComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits64 )
@@ -1441,9 +1511,10 @@ class CaseBits64ZextInComp:
       [  -1,   zext(    Bits32(-1),    64 ) ],
       [   2,   zext(     Bits32(2),    64 ) ],
   ]
+  DUT = Bits64ZextInComp
 
 class CaseBits64TruncInComp:
-  class DUT( Component ):
+  class Bits64TruncInComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits8 )
@@ -1461,9 +1532,10 @@ class CaseBits64TruncInComp:
       [  -1,   trunc(    Bits32(-1),    8 ) ],
       [   2,   trunc(     Bits32(2),    8 ) ],
   ]
+  DUT = Bits64TruncInComp
 
 class CaseBits32BitSelUpblkComp:
-  class DUT( Component ):
+  class Bits32BitSelUpblkComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits1 )
@@ -1481,9 +1553,10 @@ class CaseBits32BitSelUpblkComp:
       [  -2,   1 ],
       [   2,   1 ],
   ]
+  DUT = Bits32BitSelUpblkComp
 
 class CaseBits64PartSelUpblkComp:
-  class DUT( Component ):
+  class Bits64PartSelUpblkComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits64 )
       s.out = OutPort( Bits32 )
@@ -1504,9 +1577,10 @@ class CaseBits64PartSelUpblkComp:
       [  -32,   -2 ],
       [  -64,   -4 ],
   ]
+  DUT = Bits64PartSelUpblkComp
 
 class CasePassThroughComp:
-  class DUT( Component ):
+  class PassThroughComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits32 )
@@ -1525,9 +1599,10 @@ class CasePassThroughComp:
       [   -2,   -2 ],
       [   -1,   -1 ],
   ]
+  DUT = PassThroughComp
 
 class CaseSequentialPassThroughComp:
-  class DUT( Component ):
+  class SequentialPassThroughComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits32 )
@@ -1546,9 +1621,10 @@ class CaseSequentialPassThroughComp:
       [   -2,    24 ],
       [   -1,    -2 ],
   ]
+  DUT = SequentialPassThroughComp
 
 class CaseConnectPassThroughLongNameComp:
-  class DUT( Component ):
+  class ConnectPassThroughLongNameComp( Component ):
     def construct( s, T1, T2, T3, T4, T5, T6, T7 ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits32 )
@@ -1565,9 +1641,10 @@ class CaseConnectPassThroughLongNameComp:
       [   -2,   -2 ],
       [   -1,   -1 ],
   ]
+  DUT = ConnectPassThroughLongNameComp
 
 class CaseLambdaConnectComp:
-  class DUT( Component ):
+  class LambdaConnectComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits32 )
@@ -1586,13 +1663,15 @@ class CaseLambdaConnectComp:
       [  -42,    0 ],
       [  -41,    1 ],
   ]
+  DUT = LambdaConnectComp
 
 class CaseLambdaConnectWithListComp:
-  class DUT( Component ):
+  class LambdaConnectWithListComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = [ OutPort( Bits32 ) for _ in range(2) ]
       s.out[1] //= lambda: s.in_ + 42
+  DUT = LambdaConnectWithListComp
 
   TV_IN = \
   _set( 'in_', Bits32, 0 )
@@ -1610,7 +1689,7 @@ class CaseLambdaConnectWithListComp:
   ]
 
 class CaseBits32FooInBits32OutComp:
-  class DUT( Component ):
+  class Bits32FooInBits32OutComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits32 )
@@ -1630,25 +1709,28 @@ class CaseBits32FooInBits32OutComp:
       [   10,  10 ],
       [  256, 256 ],
   ]
+  DUT = Bits32FooInBits32OutComp
 
 class CaseBits32FooKwargComp:
-  class DUT( Component ):
+  class Bits32FooKwargComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= Bits32Foo( foo = 42 )
+  DUT = Bits32FooKwargComp
 
 class CaseBits32FooInstantiationComp:
-  class DUT( Component ):
+  class Bits32FooInstantiationComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32Foo )
       @update
       def upblk():
         s.out @= Bits32Foo( 42 )
+  DUT = Bits32FooInstantiationComp
 
 class CaseConstStructInstComp:
-  class DUT( Component ):
+  class ConstStructInstComp( Component ):
     def construct( s ):
       s.in_ = Bits32Foo()
       s.out = OutPort( Bits32 )
@@ -1663,9 +1745,10 @@ class CaseConstStructInstComp:
   [
       [ 0 ],
   ]
+  DUT = ConstStructInstComp
 
 class CaseStructPackedArrayUpblkComp:
-  class DUT( Component ):
+  class StructPackedArrayUpblkComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32x5Foo )
       s.out = OutPort( Bits96 )
@@ -1684,9 +1767,10 @@ class CaseStructPackedArrayUpblkComp:
       [  [ b32(42),b32(42),b32(42),b32(0),b32(0) ], concat( b32(42),  b32(42),  b32(42) ) ],
       [  [ b32(-1),b32(-1),b32(42),b32(0),b32(0) ], concat( b32(-1),  b32(-1),  b32(42) ) ],
   ]
+  DUT = StructPackedArrayUpblkComp
 
 class CaseConnectLiteralStructComp:
-  class DUT( Component ):
+  class ConnectLiteralStructComp( Component ):
     def construct( s ):
       s.out = OutPort( NestedStructPackedPlusScalar )
       connect( s.out, NestedStructPackedPlusScalar( 42, [ b32(1), b32(2) ], Bits32Foo(3) ) )
@@ -1698,9 +1782,10 @@ class CaseConnectLiteralStructComp:
   [
       [   NestedStructPackedPlusScalar(42, [ Bits32(1) , Bits32(2)  ], Bits32Foo(3) ) ],
   ]
+  DUT = ConnectLiteralStructComp
 
 class CaseNestedStructPackedArrayUpblkComp:
-  class DUT( Component ):
+  class NestedStructPackedArrayUpblkComp( Component ):
     def construct( s ):
       s.in_ = InPort( NestedStructPackedPlusScalar )
       s.out = OutPort( Bits96 )
@@ -1719,9 +1804,10 @@ class CaseNestedStructPackedArrayUpblkComp:
       [  NestedStructPackedPlusScalar(42, [ Bits32(42), Bits32(43) ], Bits32Foo(8) ), concat(  Bits32(42), Bits32(8),  Bits32(42) ) ],
       [  NestedStructPackedPlusScalar(42, [ Bits32(-1), Bits32(-2) ], Bits32Foo(9) ), concat(  Bits32(-1), Bits32(9),  Bits32(42) ) ],
   ]
+  DUT = NestedStructPackedArrayUpblkComp
 
 class CaseConnectNestedStructPackedArrayComp:
-  class DUT( Component ):
+  class ConnectNestedStructPackedArrayComp( Component ):
     def construct( s ):
       s.in_ = InPort( NestedStructPackedPlusScalar )
       s.out = OutPort( Bits96 )
@@ -1740,45 +1826,50 @@ class CaseConnectNestedStructPackedArrayComp:
       [  NestedStructPackedPlusScalar(42, [ Bits32(42), Bits32(43) ], Bits32Foo(8) ), concat(  Bits32(42), Bits32(8),  Bits32(42) ) ],
       [  NestedStructPackedPlusScalar(42, [ Bits32(-1), Bits32(-2) ], Bits32Foo(9) ), concat(  Bits32(-1), Bits32(9),  Bits32(42) ) ],
   ]
+  DUT = ConnectNestedStructPackedArrayComp
 
 class CaseInterfaceAttributeComp:
-  class DUT( Component ):
+  class InterfaceAttributeComp( Component ):
     def construct( s ):
       s.in_ = Bits32OutIfc()
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= s.in_.foo
+  DUT = InterfaceAttributeComp
 
 class CaseArrayInterfacesComp:
-  class DUT( Component ):
+  class ArrayInterfacesComp( Component ):
     def construct( s ):
       s.in_ = [ Bits32OutIfc() for _ in range(4) ]
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= s.in_[2].foo
+  DUT = ArrayInterfacesComp
 
 class CaseBits32SubCompPassThroughComp:
-  class DUT( Component ):
+  class Bits32SubCompPassThroughComp( Component ):
     def construct( s ):
       s.comp = Bits32OutComp()
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= s.comp.out
+  DUT = Bits32SubCompPassThroughComp
 
 class CaseArrayBits32SubCompPassThroughComp:
-  class DUT( Component ):
+  class ArrayBits32SubCompPassThroughComp( Component ):
     def construct( s ):
       s.comp = [ Bits32OutComp() for _ in range(4) ]
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= s.comp[2].out
+  DUT = ArrayBits32SubCompPassThroughComp
 
 class CaseSubCompTmpDrivenComp:
-  class DUT( Component ):
+  class SubCompTmpDrivenComp( Component ):
     def construct( s ):
       s.subcomp = Bits32OutTmpDrivenComp()
       s.out = OutPort( Bits32 )
@@ -1786,9 +1877,10 @@ class CaseSubCompTmpDrivenComp:
       def upblk():
         u = s.subcomp.out
         s.out @= u
+  DUT = SubCompTmpDrivenComp
 
 class CaseSubCompFreeVarDrivenComp:
-  class DUT( Component ):
+  class SubCompFreeVarDrivenComp( Component ):
     def construct( s ):
       s.subcomp = Bits32OutFreeVarDrivenComp()
       s.out = OutPort( Bits32 )
@@ -1798,14 +1890,16 @@ class CaseSubCompFreeVarDrivenComp:
           s.out @= s.subcomp.out
         else:
           s.out @= STATE_IDLE
+  DUT = SubCompFreeVarDrivenComp
 
 class CaseConstBits32AttrComp:
-  class DUT( Component ):
+  class ConstBits32AttrComp( Component ):
     def construct( s ):
       s.const = [ Bits32(42) for _ in range(5) ]
+  DUT = ConstBits32AttrComp
 
 class CaseInx2Outx2ConnectComp:
-  class DUT( Component ):
+  class Inx2Outx2ConnectComp( Component ):
     def construct( s ):
       s.in_1 = InPort( Bits32 )
       s.in_2 = InPort( Bits32 )
@@ -1813,16 +1907,18 @@ class CaseInx2Outx2ConnectComp:
       s.out2 = OutPort( Bits32 )
       connect( s.in_1, s.out1 )
       connect( s.in_2, s.out2 )
+  DUT = Inx2Outx2ConnectComp
 
 class CaseConnectPortIndexComp:
-  class DUT( Component ):
+  class ConnectPortIndexComp( Component ):
     def construct( s ):
       s.in_ = [ InPort( Bits32 ) for _ in range(5) ]
       s.out = OutPort( Bits32 )
       connect( s.in_[2], s.out )
+  DUT = ConnectPortIndexComp
 
 class CaseConnectInToWireComp:
-  class DUT( Component ):
+  class ConnectInToWireComp( Component ):
     def construct( s ):
       s.in_ = [ InPort( Bits32 ) for _ in range(5) ]
       s.wire_ = [ Wire( Bits32 ) for _ in range(5) ]
@@ -1848,9 +1944,10 @@ class CaseConnectInToWireComp:
       [ 0,   0,   -2,  0,  0,  -2 ],
       [ 0,   0,   -1,  0,  0,  -1 ],
   ]
+  DUT = ConnectInToWireComp
 
 class CaseWiresDrivenComp:
-  class DUT( Component ):
+  class WiresDrivenComp( Component ):
     def construct( s ):
       s.foo = Wire( Bits32 )
       s.bar = Wire( Bits4 )
@@ -1858,38 +1955,43 @@ class CaseWiresDrivenComp:
       def upblk():
         s.foo @= 42
         s.bar @= 0
+  DUT = WiresDrivenComp
 
 class CaseBits32Wirex5DrivenComp:
-  class DUT( Component ):
+  class Bits32Wirex5DrivenComp( Component ):
     def construct( s ):
       s.foo = [ Wire( Bits32 ) for _ in range(5) ]
       @update
       def upblk():
         for i in range(5):
           s.foo[i] @= 0
+  DUT = Bits32Wirex5DrivenComp
 
 class CaseStructWireDrivenComp:
-  class DUT( Component ):
+  class StructWireDrivenComp( Component ):
     def construct( s ):
       s.foo = Wire( Bits32Foo )
       @update
       def upblk():
         s.foo.foo @= 42
+  DUT = StructWireDrivenComp
 
 class CaseStructConstComp:
-  class DUT( Component ):
+  class StructConstComp( Component ):
     def construct( s ):
       s.struct_const = Bits32Foo()
+  DUT = StructConstComp
 
 class CaseNestedPackedArrayStructComp:
-  class DUT( Component ):
+  class NestedPackedArrayStructComp( Component ):
     def construct( s ):
       s.in_ = InPort( NestedStructPackedArray )
       s.out = OutPort( Bits32x5Foo )
       connect( s.in_.foo[1], s.out )
+  DUT = NestedPackedArrayStructComp
 
 class CaseConnectConstToOutComp:
-  class DUT( Component ):
+  class ConnectConstToOutComp( Component ):
     def construct( s ):
       s.const_ = [ 42 for _ in range(5) ]
       s.out = OutPort( Bits32 )
@@ -1902,9 +2004,10 @@ class CaseConnectConstToOutComp:
   [
       [ 42 ],
   ]
+  DUT = ConnectConstToOutComp
 
 class CaseConnectBitSelToOutComp:
-  class DUT( Component ):
+  class ConnectBitSelToOutComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits1 )
@@ -1922,9 +2025,10 @@ class CaseConnectBitSelToOutComp:
       [   -1,   1, ],
       [   -2,   0, ],
   ]
+  DUT = ConnectBitSelToOutComp
 
 class CaseConnectSliceToOutComp:
-  class DUT( Component ):
+  class ConnectSliceToOutComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits4 )
@@ -1942,9 +2046,10 @@ class CaseConnectSliceToOutComp:
       [   -1,  -1, ],
       [   -2,  -1, ],
   ]
+  DUT = ConnectSliceToOutComp
 
 class CaseConnectBitsConstToOutComp:
-  class DUT( Component ):
+  class ConnectBitsConstToOutComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       connect( s.out, Bits32(0) )
@@ -1956,16 +2061,18 @@ class CaseConnectBitsConstToOutComp:
   [
       [ 0 ],
   ]
+  DUT = ConnectBitsConstToOutComp
 
 class CaseConnectStructAttrToOutComp:
-  class DUT( Component ):
+  class ConnectStructAttrToOutComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits32 )
       connect( s.out, s.in_.foo )
+  DUT = ConnectStructAttrToOutComp
 
 class CaseConnectArrayStructAttrToOutComp:
-  class DUT( Component ):
+  class ConnectArrayStructAttrToOutComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32x5Foo )
       s.out = OutPort( Bits32 )
@@ -1982,9 +2089,10 @@ class CaseConnectArrayStructAttrToOutComp:
       [  [ b32(42),b32(42),b32(42),b32(0),b32(0) ], 42, ],
       [  [ b32(-1),b32(-1),b32(42),b32(0),b32(0) ], -1, ],
   ]
+  DUT = ConnectArrayStructAttrToOutComp
 
 class CaseConnectConstStructAttrToOutComp:
-  class DUT( Component ):
+  class ConnectConstStructAttrToOutComp( Component ):
     def construct( s ):
       s.in_ = Bits32Foo( 42 )
       s.out = OutPort( Bits32 )
@@ -1994,23 +2102,26 @@ class CaseConnectConstStructAttrToOutComp:
   TV_OUT = \
   _check( 'out', Bits32, 0 )
   TV =[ [ 42 ] ]
+  DUT = ConnectConstStructAttrToOutComp
 
 class CaseBits32IfcInComp:
-  class DUT( Component ):
+  class Bits32IfcInComp( Component ):
     def construct( s ):
       s.in_ = Bits32InIfc()
       s.out = OutPort( Bits32 )
       connect( s.out, s.in_.foo )
+  DUT = Bits32IfcInComp
 
 class CaseArrayBits32IfcInComp:
-  class DUT( Component ):
+  class ArrayBits32IfcInComp( Component ):
     def construct( s ):
       s.in_ = [ Bits32InIfc() for _ in range(2) ]
       s.out = OutPort( Bits32 )
       connect( s.in_[1].foo, s.out )
+  DUT = ArrayBits32IfcInComp
 
 class CaseBits32FooNoArgBehavioralComp:
-  class DUT( Component ):
+  class Bits32FooNoArgBehavioralComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32Foo )
       @update
@@ -2024,9 +2135,10 @@ class CaseBits32FooNoArgBehavioralComp:
       [    0, ],
       [    0, ],
   ]
+  DUT = Bits32FooNoArgBehavioralComp
 
 class CaseArrayBits32IfcInUpblkComp:
-  class DUT( Component ):
+  class ArrayBits32IfcInUpblkComp( Component ):
     def construct( s ):
       s.in_ = [ Bits32InIfc() for _ in range(5) ]
       s.out = OutPort( Bits32 )
@@ -2048,9 +2160,10 @@ class CaseArrayBits32IfcInUpblkComp:
       [   -2,   -1,     -1 ],
       [   -1,   -2,     -2 ],
   ]
+  DUT = ArrayBits32IfcInUpblkComp
 
 class CaseConnectValRdyIfcComp:
-  class DUT( Component ):
+  class ConnectValRdyIfcComp( Component ):
     def construct( s ):
       s.in_ = Bits32InValRdyIfc()
       s.out = Bits32OutValRdyIfc()
@@ -2077,9 +2190,10 @@ class CaseConnectValRdyIfcComp:
       [    0,     2,   0,    0,     2,    0 ],
       [    1,    24,   1,    1,    24,    1 ],
   ]
+  DUT = ConnectValRdyIfcComp
 
 class CaseConnectValRdyIfcUpblkComp:
-  class DUT( Component ):
+  class ConnectValRdyIfcUpblkComp( Component ):
     def construct( s ):
       s.in_ = Bits32InValRdyIfc()
       s.out = Bits32OutValRdyIfc()
@@ -2108,9 +2222,10 @@ class CaseConnectValRdyIfcUpblkComp:
       [    0,     2,   0,    0,     2,    0 ],
       [    1,    24,   1,    1,    24,    1 ],
   ]
+  DUT = ConnectValRdyIfcUpblkComp
 
 class CaseConnectArrayBits32FooIfcComp:
-  class DUT( Component ):
+  class ConnectArrayBits32FooIfcComp( Component ):
     def construct( s ):
       s.in_ = [ Bits32FooInIfc() for _ in range(2) ]
       s.out = [ Bits32FooOutIfc() for _ in range(2) ]
@@ -2134,9 +2249,10 @@ class CaseConnectArrayBits32FooIfcComp:
       [ 1,     -1,    1,     -1, ],
       [ 1,     -2,    1,     -2, ],
   ]
+  DUT = ConnectArrayBits32FooIfcComp
 
 class CaseConnectArrayBits32Comp:
-  class DUT( Component ):
+  class ConnectArrayBits32Comp( Component ):
     def construct( s ):
       s.in_ = [ InPort(32) for _ in range(2) ]
       s.out = [ OutPort(32) for _ in range(2) ]
@@ -2160,9 +2276,10 @@ class CaseConnectArrayBits32Comp:
       [ 1,     -1,    1,     -1, ],
       [ 1,     -2,    1,     -2, ],
   ]
+  DUT = ConnectArrayBits32Comp
 
 class CaseConnectArrayNestedIfcComp:
-  class DUT( Component ):
+  class ConnectArrayNestedIfcComp( Component ):
     def construct( s ):
       s.in_ = [ MemReqIfc() for _ in range(2) ]
       s.out = [ MemRespIfc() for _ in range(2) ]
@@ -2198,9 +2315,10 @@ class CaseConnectArrayNestedIfcComp:
       [ 1,  1,     -1,    1,    1,  1,     -1,    1,  1,  1,     -1,    1,    1,  1,     -1,    1, ],
       [ 1,  1,     -2,    0,    1,  1,     -2,    0,  1,  1,     -2,    0,    1,  1,     -2,    0, ],
   ]
+  DUT = ConnectArrayNestedIfcComp
 
 class CaseBits32IfcTmpVarOutComp:
-  class DUT( Component ):
+  class Bits32IfcTmpVarOutComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       s.ifc = Bits32OutIfc()
@@ -2208,9 +2326,10 @@ class CaseBits32IfcTmpVarOutComp:
       def upblk():
         u = s.ifc.foo
         s.out @= u
+  DUT = Bits32IfcTmpVarOutComp
 
 class CaseStructIfcTmpVarOutComp:
-  class DUT( Component ):
+  class StructIfcTmpVarOutComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       s.ifc = Bits32FooInIfc()
@@ -2218,9 +2337,10 @@ class CaseStructIfcTmpVarOutComp:
       def upblk():
         u = s.ifc.foo
         s.out @= u.foo
+  DUT = StructIfcTmpVarOutComp
 
 class CaseBits32ConnectSubCompAttrComp:
-  class DUT( Component ):
+  class Bits32ConnectSubCompAttrComp( Component ):
     def construct( s ):
       s.b = Bits32OutDrivenComp()
       s.out = OutPort( Bits32 )
@@ -2230,9 +2350,10 @@ class CaseBits32ConnectSubCompAttrComp:
   TV_OUT = \
   _check( 'out', Bits32, 0 )
   TV =[ [ 42 ] ]
+  DUT = Bits32ConnectSubCompAttrComp
 
 class CaseBits32SubCompAttrUpblkComp:
-  class DUT( Component ):
+  class Bits32SubCompAttrUpblkComp( Component ):
     def construct( s ):
       s.b = Bits32OutDrivenComp()
       s.out = OutPort( Bits32 )
@@ -2247,9 +2368,10 @@ class CaseBits32SubCompAttrUpblkComp:
   [
       [ 42 ],
   ]
+  DUT = Bits32SubCompAttrUpblkComp
 
 class CaseConnectSubCompIfcHierarchyComp:
-  class DUT( Component ):
+  class ConnectSubCompIfcHierarchyComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       s.ifc = Bits32OutValRdyIfc()
@@ -2265,9 +2387,10 @@ class CaseConnectSubCompIfcHierarchyComp:
       'ifc.val', Bits1,  2,
   )
   TV =[ [ 42, 42, 1 ] ]
+  DUT = ConnectSubCompIfcHierarchyComp
 
 class CaseConnectArraySubCompArrayStructIfcComp:
-  class DUT( Component ):
+  class ConnectArraySubCompArrayStructIfcComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits32 )
@@ -2285,9 +2408,10 @@ class CaseConnectArraySubCompArrayStructIfcComp:
       [ -1, -1 ],
       [ -2, -2 ],
   ]
+  DUT = ConnectArraySubCompArrayStructIfcComp
 
 class CaseBehavioralArraySubCompArrayStructIfcComp:
-  class DUT( Component ):
+  class BehavioralArraySubCompArrayStructIfcComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits32 )
@@ -2309,9 +2433,10 @@ class CaseBehavioralArraySubCompArrayStructIfcComp:
       [ -1, -1 ],
       [ -2, -2 ],
   ]
+  DUT = BehavioralArraySubCompArrayStructIfcComp
 
 class CaseBits32ArrayConnectSubCompAttrComp:
-  class DUT( Component ):
+  class Bits32ArrayConnectSubCompAttrComp( Component ):
     def construct( s ):
       s.b = [ Bits32OutDrivenComp() for _ in range(5) ]
       s.out = OutPort( Bits32 )
@@ -2323,9 +2448,10 @@ class CaseBits32ArrayConnectSubCompAttrComp:
       'out',     Bits32, 0,
   )
   TV =[ [ 42 ] ]
+  DUT = Bits32ArrayConnectSubCompAttrComp
 
 class CaseBits32ArraySubCompAttrUpblkComp:
-  class DUT( Component ):
+  class Bits32ArraySubCompAttrUpblkComp( Component ):
     def construct( s ):
       s.b = [ Bits32OutDrivenComp() for _ in range(5) ]
       s.out = OutPort( Bits32 )
@@ -2340,24 +2466,28 @@ class CaseBits32ArraySubCompAttrUpblkComp:
   [
       [ 42 ],
   ]
+  DUT = Bits32ArraySubCompAttrUpblkComp
 
 class CaseComponentArgsComp:
-  class DUT( Component ):
+  class ComponentArgsComp( Component ):
     def construct( s, foo, bar ):
       pass
+  DUT = ComponentArgsComp
 
 class CaseComponentDefaultArgsComp:
-  class DUT( Component ):
+  class ComponentDefaultArgsComp( Component ):
     def construct( s, foo, bar = Bits16(42) ):
       pass
+  DUT = ComponentDefaultArgsComp
 
 class CaseMixedDefaultArgsComp:
-  class DUT( Component ):
+  class MixedDefaultArgsComp( Component ):
     def construct( s, foo, bar, woo = Bits32(0) ):
       pass
+  DUT = MixedDefaultArgsComp
 
 class CaseGenericAdderComp:
-  class DUT( Component ):
+  class GenericAdderComp( Component ):
     def construct( s, Type ):
       s.in_1 = InPort( Type )
       s.in_2 = InPort( Type )
@@ -2366,9 +2496,10 @@ class CaseGenericAdderComp:
       def add_upblk():
         s.out @= s.in_1 + s.in_2
     def line_trace( s ): return 'sum = ' + str(s.out)
+  DUT = GenericAdderComp
 
 class CaseGenericMuxComp:
-  class DUT( Component ):
+  class GenericMuxComp( Component ):
     def construct( s, Type, n_ports ):
       s.in_ = [ InPort( Type ) for _ in range(n_ports) ]
       s.sel = InPort( mk_bits( clog2(n_ports) ) )
@@ -2377,17 +2508,19 @@ class CaseGenericMuxComp:
       def add_upblk():
         s.out @= s.in_[ s.sel ]
     def line_trace( s ): return "out = " + str( s.out )
+  DUT = GenericMuxComp
 
 class CaseStructConnectWireComp:
-  class DUT( Component ):
+  class StructConnectWireComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits32 )
       connect( s.out, s.in_.foo )
     def line_trace( s ): return "out = " + str( s.out )
+  DUT = StructConnectWireComp
 
 class CaseNestedStructConnectWireComp:
-  class DUT( Component ):
+  class NestedStructConnectWireComp( Component ):
     def construct( s ):
       s.in_ = InPort( MultiDimPackedArrayStruct )
       s.out_foo = OutPort( Bits32 )
@@ -2402,9 +2535,10 @@ class CaseNestedStructConnectWireComp:
       connect( s.out_foo, s.in_.foo )
       connect( s.out_bar, s.in_.inner.bar )
     def line_trace( s ): return "out_sum = " + str( s.out_sum )
+  DUT = NestedStructConnectWireComp
 
 class CaseNestedStructConnectWireSubComp:
-  class DUT( Component ):
+  class NestedStructConnectWireSubComp( Component ):
     def construct( s ):
       s.b = Bits32OutDrivenComp()
       s.in_ = InPort( MultiDimPackedArrayStruct )
@@ -2420,9 +2554,10 @@ class CaseNestedStructConnectWireSubComp:
       connect( s.out_foo, s.b.out )
       connect( s.out_bar, s.in_.inner.bar )
     def line_trace( s ): return "out_sum = " + str( s.out_sum )
+  DUT = NestedStructConnectWireSubComp
 
 class CaseGenericConditionalDriveComp:
-  class DUT( Component ):
+  class GenericConditionalDriveComp( Component ):
     def construct( s, Type ):
       s.in_ = [InPort ( Type ) for _ in range(2)]
       s.out = [OutPort( Type ) for _ in range(2)]
@@ -2438,9 +2573,10 @@ class CaseGenericConditionalDriveComp:
                                 "s.in1  = " + str( s.in_[1] ) +\
                                 "s.out0 = " + str( s.out[0] ) +\
                                 "s.out1 = " + str( s.out[1] )
+  DUT = GenericConditionalDriveComp
 
 class CaseBitSelOverBitSelComp:
-  class DUT( Component ):
+  class BitSelOverBitSelComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits1 )
@@ -2455,9 +2591,10 @@ class CaseBitSelOverBitSelComp:
       [ 4, 0 ],
       [ 5, 0 ],
   ]
+  DUT = BitSelOverBitSelComp
 
 class CaseBitSelOverPartSelComp:
-  class DUT( Component ):
+  class BitSelOverPartSelComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits1 )
@@ -2472,9 +2609,10 @@ class CaseBitSelOverPartSelComp:
       [ 4, 0 ],
       [ 5, 1 ],
   ]
+  DUT = BitSelOverPartSelComp
 
 class CasePartSelOverBitSelComp:
-  class DUT( Component ):
+  class PartSelOverBitSelComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits1 )
@@ -2489,9 +2627,10 @@ class CasePartSelOverBitSelComp:
       [ 4, 0 ],
       [ 5, 0 ],
   ]
+  DUT = PartSelOverBitSelComp
 
 class CasePartSelOverPartSelComp:
-  class DUT( Component ):
+  class PartSelOverPartSelComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits1 )
@@ -2506,9 +2645,10 @@ class CasePartSelOverPartSelComp:
       [ 4, 0 ],
       [ 5, 1 ],
   ]
+  DUT = PartSelOverPartSelComp
 
 class CaseDefaultBitsComp:
-  class DUT( Component ):
+  class DefaultBitsComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       @update
@@ -2521,30 +2661,33 @@ class CaseDefaultBitsComp:
       [ 0 ],
       [ 0 ],
   ]
+  DUT = DefaultBitsComp
 
 #-------------------------------------------------------------------------
 # Test cases that contain SystemVerilog translator errors
 #-------------------------------------------------------------------------
 
 class CaseVerilogReservedComp:
-  class DUT( Component ):
+  class VerilogReservedComp( Component ):
     def construct( s ):
       s.buf = InPort( Bits32 )
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= s.buf
+  DUT = VerilogReservedComp
 
 class CaseUpdateffMixAssignComp:
-  class DUT( Component ):
+  class UpdateffMixAssignComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         tmpvar = s.out = Bits32(42)
+  DUT = UpdateffMixAssignComp
 
 class CaseInterfaceArrayNonStaticIndexComp:
-  class DUT( Component ):
+  class InterfaceArrayNonStaticIndexComp( Component ):
     def construct( s ):
       s.in_ = [ Bits32InIfc() for _ in range(2) ]
       s.out = OutPort( Bits32 )
@@ -2566,85 +2709,94 @@ class CaseInterfaceArrayNonStaticIndexComp:
       [  1,  -1,   -1 ],
       [  1,  42,   42 ],
   ]
+  DUT = InterfaceArrayNonStaticIndexComp
 
 #-------------------------------------------------------------------------
 # Test cases that contain errors
 #-------------------------------------------------------------------------
 
 class CaseStructBitsUnagreeableComp:
-  class DUT( Component ):
+  class StructBitsUnagreeableComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits16 )
       @update
       def upblk():
         s.out @= s.in_
+  DUT = StructBitsUnagreeableComp
 
 class CaseConcatComponentComp:
-  class DUT( Component ):
+  class ConcatComponentComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits8 )
       s.out = OutPort( Bits16 )
       @update
       def upblk():
         s.out @= concat( s, s.in_ )
+  DUT = ConcatComponentComp
 
 class CaseZextVaribleNbitsComp:
-  class DUT( Component ):
+  class ZextVaribleNbitsComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits8 )
       s.out = OutPort( Bits16 )
       @update
       def upblk():
         s.out @= zext( s.in_, s.in_ )
+  DUT = ZextVaribleNbitsComp
 
 class CaseZextSmallNbitsComp:
-  class DUT( Component ):
+  class ZextSmallNbitsComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits8 )
       s.out = OutPort( Bits16 )
       @update
       def upblk():
         s.out @= zext( s.in_, 4 )
+  DUT = ZextSmallNbitsComp
 
 class CaseSextVaribleNbitsComp:
-  class DUT( Component ):
+  class SextVaribleNbitsComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits8 )
       s.out = OutPort( Bits16 )
       @update
       def upblk():
         s.out @= sext( s.in_, s.in_ )
+  DUT = SextVaribleNbitsComp
 
 class CaseSextSmallNbitsComp:
-  class DUT( Component ):
+  class SextSmallNbitsComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits8 )
       s.out = OutPort( Bits16 )
       @update
       def upblk():
         s.out @= sext( s.in_, 4 )
+  DUT = SextSmallNbitsComp
 
 class CaseTruncVaribleNbitsComp:
-  class DUT( Component ):
+  class TruncVaribleNbitsComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits8 )
       s.out = OutPort( Bits16 )
       @update
       def upblk():
         s.out @= trunc( s.in_, s.in_ )
+  DUT = TruncVaribleNbitsComp
 
 class CaseTruncLargeNbitsComp:
-  class DUT( Component ):
+  class TruncLargeNbitsComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits8 )
       s.out = OutPort( Bits16 )
       @update
       def upblk():
         s.out @= trunc( s.in_, 16 )
+  DUT = TruncLargeNbitsComp
 
 class CaseDroppedAttributeComp:
-  class DUT( Component ):
+  class DroppedAttributeComp( Component ):
     def construct( s ):
       # s.in_ is not recognized by RTLIR and will be dropped
       s.in_ = 'string'
@@ -2652,9 +2804,10 @@ class CaseDroppedAttributeComp:
       @update
       def upblk():
         s.out @= s.in_
+  DUT = DroppedAttributeComp
 
 class CaseL1UnsupportedSubCompAttrComp:
-  class DUT( Component ):
+  class L1UnsupportedSubCompAttrComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits4 )
       s.out = [ OutPort( Bits1 ) for _ in range(5) ]
@@ -2662,54 +2815,60 @@ class CaseL1UnsupportedSubCompAttrComp:
       @update
       def upblk():
         s.out @= s.comp_array[ 0 ].out
+  DUT = L1UnsupportedSubCompAttrComp
 
 class CaseIndexOutOfRangeComp:
-  class DUT( Component ):
+  class IndexOutOfRangeComp( Component ):
     def construct( s ):
       s.in_ = [ InPort( Bits1 ) for _ in range(4) ]
       s.out = OutPort( Bits1 )
       @update
       def upblk():
         s.out @= s.in_[4]
+  DUT = IndexOutOfRangeComp
 
 class CaseBitSelOutOfRangeComp:
-  class DUT( Component ):
+  class BitSelOutOfRangeComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits4 )
       s.out = OutPort( Bits1 )
       @update
       def upblk():
         s.out @= s.in_[4]
+  DUT = BitSelOutOfRangeComp
 
 class CaseIndexOnStructComp:
-  class DUT( Component ):
+  class IndexOnStructComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32x5Foo )
       s.out = OutPort( Bits1 )
       @update
       def upblk():
         s.out @= s.in_[16]
+  DUT = IndexOnStructComp
 
 class CaseSliceOnStructComp:
-  class DUT( Component ):
+  class SliceOnStructComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32x5Foo )
       s.out = OutPort( Bits1 )
       @update
       def upblk():
         s.out @= s.in_[0:16]
+  DUT = SliceOnStructComp
 
 class CaseSliceBoundLowerComp:
-  class DUT( Component ):
+  class SliceBoundLowerComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits4 )
       s.out = OutPort( Bits1 )
       @update
       def upblk():
         s.out @= s.in_[4:0]
+  DUT = SliceBoundLowerComp
 
 class CaseSliceVariableBoundComp:
-  class DUT( Component ):
+  class SliceVariableBoundComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits4 )
       s.slice_l = InPort( Bits2 )
@@ -2718,92 +2877,103 @@ class CaseSliceVariableBoundComp:
       @update
       def upblk():
         s.out @= s.in_[s.slice_l:s.slice_r]
+  DUT = SliceVariableBoundComp
 
 class CaseSliceOutOfRangeComp:
-  class DUT( Component ):
+  class SliceOutOfRangeComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits4 )
       s.out = OutPort( Bits1 )
       @update
       def upblk():
         s.out @= s.in_[0:5]
+  DUT = SliceOutOfRangeComp
 
 class CaseLHSConstComp:
-  class DUT( Component ):
+  class LHSConstComp( Component ):
     def construct( s ):
       u, s.v = 42, 42
       @update
       def upblk():
         s.v @= u
+  DUT = LHSConstComp
 
 class CaseLHSComponentComp:
-  class DUT( Component ):
+  class LHSComponentComp( Component ):
     def construct( s ):
       s.u = Bits16InOutPassThroughComp()
       @update
       def upblk():
         s.u @= 42
+  DUT = LHSComponentComp
 
 class CaseRHSComponentComp:
-  class DUT( Component ):
+  class RHSComponentComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= s
+  DUT = RHSComponentComp
 
 class CaseZextOnComponentComp:
-  class DUT( Component ):
+  class ZextOnComponentComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= zext( s, 1 )
+  DUT = ZextOnComponentComp
 
 class CaseSextOnComponentComp:
-  class DUT( Component ):
+  class SextOnComponentComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= sext( s, 1 )
+  DUT = SextOnComponentComp
 
 class CaseSizeCastComponentComp:
-  class DUT( Component ):
+  class SizeCastComponentComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= Bits32( s )
+  DUT = SizeCastComponentComp
 
 class CaseAttributeSignalComp:
-  class DUT( Component ):
+  class AttributeSignalComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= s.in_.foo
+  DUT = AttributeSignalComp
 
 class CaseComponentInIndexComp:
-  class DUT( Component ):
+  class ComponentInIndexComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= s.in_[ s ]
+  DUT = ComponentInIndexComp
 
 class CaseComponentBaseIndexComp:
-  class DUT( Component ):
+  class ComponentBaseIndexComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= s[ 1 ]
+  DUT = ComponentBaseIndexComp
 
 class CaseComponentLowerSliceComp:
-  class DUT( Component ):
+  class ComponentLowerSliceComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.idx = Bits16InOutPassThroughComp()
@@ -2811,9 +2981,10 @@ class CaseComponentLowerSliceComp:
       @update
       def upblk():
         s.out @= s.in_[ s.idx:4 ]
+  DUT = ComponentLowerSliceComp
 
 class CaseComponentHigherSliceComp:
-  class DUT( Component ):
+  class ComponentHigherSliceComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.idx = Bits16InOutPassThroughComp()
@@ -2821,394 +2992,445 @@ class CaseComponentHigherSliceComp:
       @update
       def upblk():
         s.out @= s.in_[ 0:s.idx ]
+  DUT = ComponentHigherSliceComp
 
 class CaseSliceOnComponentComp:
-  class DUT( Component ):
+  class SliceOnComponentComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= s[ 0:4 ]
+  DUT = SliceOnComponentComp
 
 class CaseUpblkArgComp:
-  class DUT( Component ):
+  class UpblkArgComp( Component ):
     def construct( s ):
       @update
       def upblk( number ):
         u = number
+  DUT = UpblkArgComp
 
 class CaseAssignMultiTargetComp:
-  class DUT( Component ):
+  class AssignMultiTargetComp( Component ):
     def construct( s ):
       @update
       def upblk():
         u = v = x = y
+  DUT = AssignMultiTargetComp
 
 class CaseCopyArgsComp:
-  class DUT( Component ):
+  class CopyArgsComp( Component ):
     def construct( s ):
       @update
       def upblk():
         u = copy(42, 10)
+  DUT = CopyArgsComp
 
 class CaseDeepcopyArgsComp:
-  class DUT( Component ):
+  class DeepcopyArgsComp( Component ):
     def construct( s ):
       @update
       def upblk():
         u = deepcopy(42, 10)
+  DUT = DeepcopyArgsComp
 
 class CaseSliceWithStepsComp:
-  class DUT( Component ):
+  class SliceWithStepsComp( Component ):
     def construct( s ):
       v = 42
       @update
       def upblk():
         u = v[ 0:16:4 ]
+  DUT = SliceWithStepsComp
 
 class CaseExtendedSubscriptComp:
-  class DUT( Component ):
+  class ExtendedSubscriptComp( Component ):
     def construct( s ):
       v = 42
       @update
       def upblk():
         u = v[ 0:8, 16:24 ]
+  DUT = ExtendedSubscriptComp
 
 class CaseTmpComponentComp:
-  class DUT( Component ):
+  class TmpComponentComp( Component ):
     def construct( s ):
       v = Bits16InOutPassThroughComp()
       @update
       def upblk():
         u = v
+  DUT = TmpComponentComp
 
 class CaseUntypedTmpComp:
-  class DUT( Component ):
+  class UntypedTmpComp( Component ):
     def construct( s ):
       @update
       def upblk():
         u = 42
+  DUT = UntypedTmpComp
 
 class CaseStarArgsComp:
-  class DUT( Component ):
+  class StarArgsComp( Component ):
     def construct( s ):
       @update
       def upblk():
         x = x(*x)
+  DUT = StarArgsComp
 
 class CaseDoubleStarArgsComp:
-  class DUT( Component ):
+  class DoubleStarArgsComp( Component ):
     def construct( s ):
       @update
       def upblk():
         x = x(**x)
+  DUT = DoubleStarArgsComp
 
 class CaseKwArgsComp:
-  class DUT( Component ):
+  class KwArgsComp( Component ):
     def construct( s ):
       xx = 42
       @update
       def upblk():
         x = x(x=x)
+  DUT = KwArgsComp
 
 class CaseNonNameCalledComp:
-  class DUT( Component ):
+  class NonNameCalledComp( Component ):
     def construct( s ):
       import copy
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= copy.copy( 42 )
+  DUT = NonNameCalledComp
 
 class CaseFuncNotFoundComp:
-  class DUT( Component ):
+  class FuncNotFoundComp( Component ):
     def construct( s ):
       @update
       def upblk():
         t = undefined_func(u)
+  DUT = FuncNotFoundComp
 
 class CaseBitsArgsComp:
-  class DUT( Component ):
+  class BitsArgsComp( Component ):
     def construct( s ):
       @update
       def upblk():
         x = Bits32( 42, 42 )
+  DUT = BitsArgsComp
 
 class CaseConcatNoArgsComp:
-  class DUT( Component ):
+  class ConcatNoArgsComp( Component ):
     def construct( s ):
       @update
       def upblk():
         x = concat()
+  DUT = ConcatNoArgsComp
 
 class CaseZextTwoArgsComp:
-  class DUT( Component ):
+  class ZextTwoArgsComp( Component ):
     def construct( s ):
       @update
       def upblk():
         x = zext( s )
+  DUT = ZextTwoArgsComp
 
 class CaseSextTwoArgsComp:
-  class DUT( Component ):
+  class SextTwoArgsComp( Component ):
     def construct( s ):
       @update
       def upblk():
         x = sext( s )
+  DUT = SextTwoArgsComp
 
 class CaseUnrecognizedFuncComp:
-  class DUT( Component ):
+  class UnrecognizedFuncComp( Component ):
     def construct( s ):
       def foo(): pass
       @update
       def upblk():
         x = foo()
+  DUT = UnrecognizedFuncComp
 
 class CaseStandaloneExprComp:
-  class DUT( Component ):
+  class StandaloneExprComp( Component ):
     def construct( s ):
       @update
       def upblk():
         42
+  DUT = StandaloneExprComp
 
 class CaseLambdaFuncComp:
-  class DUT( Component ):
+  class LambdaFuncComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= lambda: 42
+  DUT = LambdaFuncComp
 
 class CaseDictComp:
-  class DUT( Component ):
+  class DictComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= { 1:42 }
+  DUT = DictComp
 
 class CaseSetComp:
-  class DUT( Component ):
+  class SetComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= { 42 }
+  DUT = SetComp
 
 class CaseListComp:
-  class DUT( Component ):
+  class ListComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= [ 42 ]
+  DUT = ListComp
 
 class CaseTupleComp:
-  class DUT( Component ):
+  class TupleComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= ( 42, )
+  DUT = TupleComp
 
 class CaseListComprehensionComp:
-  class DUT( Component ):
+  class ListComprehensionComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= [ 42 for _ in range(1) ]
+  DUT = ListComprehensionComp
 
 class CaseSetComprehensionComp:
-  class DUT( Component ):
+  class SetComprehensionComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= { 42 for _ in range(1) }
+  DUT = SetComprehensionComp
 
 class CaseDictComprehensionComp:
-  class DUT( Component ):
+  class DictComprehensionComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= { 1:42 for _ in range(1) }
+  DUT = DictComprehensionComp
 
 class CaseGeneratorExprComp:
-  class DUT( Component ):
+  class GeneratorExprComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= ( 42 for _ in range(1) )
+  DUT = GeneratorExprComp
 
 class CaseYieldComp:
-  class DUT( Component ):
+  class YieldComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= yield
+  DUT = YieldComp
 
 class CaseReprComp:
-  class DUT( Component ):
+  class ReprComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         # Python 2 only: s.out = `42`
         s.out @= repr(42)
+  DUT = ReprComp
 
 class CaseStrComp:
-  class DUT( Component ):
+  class StrComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= '42'
+  DUT = StrComp
 
 class CaseClassdefComp:
-  class DUT( Component ):
+  class ClassdefComp( Component ):
     def construct( s ):
       @update
       def upblk():
         class c: pass
+  DUT = ClassdefComp
 
 class CaseDeleteComp:
-  class DUT( Component ):
+  class DeleteComp( Component ):
     def construct( s ):
       @update
       def upblk():
         del u
+  DUT = DeleteComp
 
 class CaseWithComp:
-  class DUT( Component ):
+  class WithComp( Component ):
     def construct( s ):
       @update
       def upblk():
         with u: 42
+  DUT = WithComp
 
 class CaseRaiseComp:
-  class DUT( Component ):
+  class RaiseComp( Component ):
     def construct( s ):
       @update
       def upblk():
         raise 42
+  DUT = RaiseComp
 
 class CaseTryExceptComp:
-  class DUT( Component ):
+  class TryExceptComp( Component ):
     def construct( s ):
       @update
       def upblk():
         try: 42
         except: 42
+  DUT = TryExceptComp
 
 class CaseTryFinallyComp:
-  class DUT( Component ):
+  class TryFinallyComp( Component ):
     def construct( s ):
       @update
       def upblk():
         try: 42
         finally: 42
+  DUT = TryFinallyComp
 
 class CaseImportComp:
-  class DUT( Component ):
+  class ImportComp( Component ):
     def construct( s ):
       x = 42
       @update
       def upblk():
         import x
+  DUT = ImportComp
 
 class CaseImportFromComp:
-  class DUT( Component ):
+  class ImportFromComp( Component ):
     def construct( s ):
       x = 42
       @update
       def upblk():
         from x import x
+  DUT = ImportFromComp
 
 class CaseExecComp:
-  class DUT( Component ):
+  class ExecComp( Component ):
     def construct( s ):
       @update
       def upblk():
         # Python 2 only: exec 42
         exec(42)
+  DUT = ExecComp
 
 class CaseGlobalComp:
-  class DUT( Component ):
+  class GlobalComp( Component ):
     def construct( s ):
       u = 42
       @update
       def upblk():
         global u
+  DUT = GlobalComp
 
 class CasePassComp:
-  class DUT( Component ):
+  class PassComp( Component ):
     def construct( s ):
       @update
       def upblk():
         pass
+  DUT = PassComp
 
 class CaseWhileComp:
-  class DUT( Component ):
+  class WhileComp( Component ):
     def construct( s ):
       @update
       def upblk():
         while 42: 42
+  DUT = WhileComp
 
 class CaseExtSliceComp:
-  class DUT( Component ):
+  class ExtSliceComp( Component ):
     def construct( s ):
       @update
       def upblk():
         42[ 1:2:3, 2:4:6 ]
+  DUT = ExtSliceComp
 
 class CaseAddComponentComp:
-  class DUT( Component ):
+  class AddComponentComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits1 )
       @update
       def upblk():
         s.out @= Bits1( 1 ) + s
+  DUT = AddComponentComp
 
 class CaseInvComponentComp:
-  class DUT( Component ):
+  class InvComponentComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits1 )
       @update
       def upblk():
         s.out @= ~s
+  DUT = InvComponentComp
 
 class CaseComponentStartRangeComp:
-  class DUT( Component ):
+  class ComponentStartRangeComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits1 )
       @update
       def upblk():
         for i in range( s, 8, 1 ):
           s.out @= ~Bits1( 1 )
+  DUT = ComponentStartRangeComp
 
 class CaseComponentEndRangeComp:
-  class DUT( Component ):
+  class ComponentEndRangeComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits1 )
       @update
       def upblk():
         for i in range( 0, s, 1 ):
           s.out @= ~Bits1( 1 )
+  DUT = ComponentEndRangeComp
 
 class CaseComponentStepRangeComp:
-  class DUT( Component ):
+  class ComponentStepRangeComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits1 )
       @update
       def upblk():
         for i in range( 0, 8, s ):
           s.out @= ~Bits1( 1 )
+  DUT = ComponentStepRangeComp
 
 class CaseComponentIfCondComp:
-  class DUT( Component ):
+  class ComponentIfCondComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits1 )
       @update
@@ -3217,33 +3439,37 @@ class CaseComponentIfCondComp:
           s.out @= Bits1( 1 )
         else:
           s.out @= ~Bits1( 1 )
+  DUT = ComponentIfCondComp
 
 class CaseComponentIfExpCondComp:
-  class DUT( Component ):
+  class ComponentIfExpCondComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits1 )
       @update
       def upblk():
         s.out @= Bits1(1) if s else ~Bits1(1)
+  DUT = ComponentIfExpCondComp
 
 class CaseComponentIfExpBodyComp:
-  class DUT( Component ):
+  class ComponentIfExpBodyComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits1 )
       @update
       def upblk():
         s.out @= s if 1 else ~Bits1(1)
+  DUT = ComponentIfExpBodyComp
 
 class CaseComponentIfExpElseComp:
-  class DUT( Component ):
+  class ComponentIfExpElseComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits1 )
       @update
       def upblk():
         s.out @= Bits1(1) if 1 else s
+  DUT = ComponentIfExpElseComp
 
 class CaseStructIfCondComp:
-  class DUT( Component ):
+  class StructIfCondComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits1 )
@@ -3253,18 +3479,20 @@ class CaseStructIfCondComp:
           s.out @= Bits1(1)
         else:
           s.out @= ~Bits1(1)
+  DUT = StructIfCondComp
 
 class CaseZeroStepRangeComp:
-  class DUT( Component ):
+  class ZeroStepRangeComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits1 )
       @update
       def upblk():
         for i in range( 0, 4, 0 ):
           s.out @= Bits1( 1 )
+  DUT = ZeroStepRangeComp
 
 class CaseVariableStepRangeComp:
-  class DUT( Component ):
+  class VariableStepRangeComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits2 )
       s.out = OutPort( Bits1 )
@@ -3272,71 +3500,79 @@ class CaseVariableStepRangeComp:
       def upblk():
         for i in range( 0, 4, s.in_ ):
           s.out @= Bits1( 1 )
+  DUT = VariableStepRangeComp
 
 class CaseStructIfExpCondComp:
-  class DUT( Component ):
+  class StructIfExpCondComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits1 )
       @update
       def upblk():
         s.out @= Bits1(1) if s.in_ else ~Bits1(1)
+  DUT = StructIfExpCondComp
 
 class CaseDifferentTypesIfExpComp:
-  class DUT( Component ):
+  class DifferentTypesIfExpComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits1 )
       @update
       def upblk():
         s.out @= Bits1(1) if 1 else s.in_
+  DUT = DifferentTypesIfExpComp
 
 class CaseNotStructComp:
-  class DUT( Component ):
+  class NotStructComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits1 )
       @update
       def upblk():
         s.out @= ~ s.in_
+  DUT = NotStructComp
 
 class CaseAndStructComp:
-  class DUT( Component ):
+  class AndStructComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits1 )
       @update
       def upblk():
         s.out @= Bits1( 1 ) & s.in_
+  DUT = AndStructComp
 
 class CaseAddStructBits1Comp:
-  class DUT( Component ):
+  class AddStructBits1Comp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits1 )
       @update
       def upblk():
         s.out @= Bits1( 1 ) + s.in_
+  DUT = AddStructBits1Comp
 
 class CaseExplicitBoolComp:
-  class DUT( Component ):
+  class ExplicitBoolComp( Component ):
     def construct( s ):
       Bool = rdt.Bool
       s.out = OutPort( Bits1 )
       @update
       def upblk():
         s.out @= Bool( Bits1(1) )
+  DUT = ExplicitBoolComp
 
 class CaseTmpVarUsedBeforeAssignmentComp:
-  class DUT( Component ):
+  class TmpVarUsedBeforeAssignmentComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits4 )
       @update
       def upblk():
         s.out @= u + Bits4( 1 )
+  DUT = TmpVarUsedBeforeAssignmentComp
 
 class CaseForLoopElseComp:
-  class DUT( Component ):
+  class ForLoopElseComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits4 )
       @update
@@ -3345,9 +3581,10 @@ class CaseForLoopElseComp:
           s.out @= Bits4( 1 )
         else:
           s.out @= Bits4( 1 )
+  DUT = ForLoopElseComp
 
 class CaseSignalAsLoopIndexComp:
-  class DUT( Component ):
+  class SignalAsLoopIndexComp( Component ):
     def construct( s ):
       s.in_ = Wire( Bits4 )
       s.out = OutPort( Bits4 )
@@ -3355,9 +3592,10 @@ class CaseSignalAsLoopIndexComp:
       def upblk():
         for s.in_ in range(4):
           s.out @= Bits4( 1 )
+  DUT = SignalAsLoopIndexComp
 
 class CaseRedefLoopIndexComp:
-  class DUT( Component ):
+  class RedefLoopIndexComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits4 )
       @update
@@ -3365,9 +3603,10 @@ class CaseRedefLoopIndexComp:
         for i in range(4):
           for i in range(4):
             s.out @= Bits4( 1 )
+  DUT = RedefLoopIndexComp
 
 class CaseSignalAfterInComp:
-  class DUT( Component ):
+  class SignalAfterInComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits2 )
       s.out = OutPort( Bits4 )
@@ -3375,9 +3614,10 @@ class CaseSignalAfterInComp:
       def upblk():
         for i in s.in_:
           s.out @= Bits4( 1 )
+  DUT = SignalAfterInComp
 
 class CaseFuncCallAfterInComp:
-  class DUT( Component ):
+  class FuncCallAfterInComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits4 )
       def foo(): pass
@@ -3385,138 +3625,156 @@ class CaseFuncCallAfterInComp:
       def upblk():
         for i in foo():
           s.out @= Bits4( 1 )
+  DUT = FuncCallAfterInComp
 
 class CaseNoArgsToRangeComp:
-  class DUT( Component ):
+  class NoArgsToRangeComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits4 )
       @update
       def upblk():
         for i in range():
           s.out @= Bits4( 1 )
+  DUT = NoArgsToRangeComp
 
 class CaseTooManyArgsToRangeComp:
-  class DUT( Component ):
+  class TooManyArgsToRangeComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits4 )
       @update
       def upblk():
         for i in range( 0, 4, 1, 1 ):
           s.out @= Bits4( 1 )
+  DUT = TooManyArgsToRangeComp
 
 class CaseInvalidIsComp:
-  class DUT( Component ):
+  class InvalidIsComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits4 )
       @update
       def upblk():
         s.out @= Bits1( 1 ) is Bits1( 1 )
+  DUT = InvalidIsComp
 
 class CaseInvalidIsNotComp:
-  class DUT( Component ):
+  class InvalidIsNotComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits4 )
       @update
       def upblk():
         s.out @= Bits1( 1 ) is not Bits1( 1 )
+  DUT = InvalidIsNotComp
 
 class CaseInvalidInComp:
-  class DUT( Component ):
+  class InvalidInComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits4 )
       @update
       def upblk():
         s.out @= Bits1( 1 ) in Bits1( 1 )
+  DUT = InvalidInComp
 
 class CaseInvalidNotInComp:
-  class DUT( Component ):
+  class InvalidNotInComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits4 )
       @update
       def upblk():
         s.out @= Bits1( 1 ) not in Bits1( 1 )
+  DUT = InvalidNotInComp
 
 class CaseInvalidDivComp:
-  class DUT( Component ):
+  class InvalidDivComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits4 )
       @update
       def upblk():
         s.out @= Bits1( 1 ) // Bits1( 1 )
+  DUT = InvalidDivComp
 
 class CaseMultiOpComparisonComp:
-  class DUT( Component ):
+  class MultiOpComparisonComp( Component ):
     def construct( s ):
       s.out = OutPort( Bits4 )
       @update
       def upblk():
         s.out @= Bits1( 0 ) <= Bits2( 1 ) <= Bits2( 2 )
+  DUT = MultiOpComparisonComp
 
 class CaseInvalidBreakComp:
-  class DUT( Component ):
+  class InvalidBreakComp( Component ):
     def construct( s ):
       @update
       def upblk():
         for i in range(42): break
+  DUT = InvalidBreakComp
 
 class CaseInvalidContinueComp:
-  class DUT( Component ):
+  class InvalidContinueComp( Component ):
     def construct( s ):
       @update
       def upblk():
         for i in range(42): continue
+  DUT = InvalidContinueComp
 
 class CaseBitsAttributeComp:
-  class DUT( Component ):
+  class BitsAttributeComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits1 )
       @update
       def upblk():
         s.out @= s.in_.foo
+  DUT = BitsAttributeComp
 
 class CaseStructMissingAttributeComp:
-  class DUT( Component ):
+  class StructMissingAttributeComp( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits1 )
       @update
       def upblk():
         s.out @= s.in_.bar
+  DUT = StructMissingAttributeComp
 
 class CaseInterfaceMissingAttributeComp:
-  class DUT( Component ):
+  class InterfaceMissingAttributeComp( Component ):
     def construct( s ):
       s.in_ = Bits32OutIfc()
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= s.in_.bar
+  DUT = InterfaceMissingAttributeComp
 
 class CaseSubCompMissingAttributeComp:
-  class DUT( Component ):
+  class SubCompMissingAttributeComp( Component ):
     def construct( s ):
       s.comp = Bits32OutComp()
       s.out = OutPort( Bits32 )
       @update
       def upblk():
         s.out @= s.comp.bar
+  DUT = SubCompMissingAttributeComp
 
 class CaseCrossHierarchyAccessComp:
-  class DUT( Component ):
+  class CrossHierarchyAccessComp( Component ):
     def construct( s ):
       s.comp = WrappedBits32OutComp()
       s.a_out = OutPort( Bits32 )
       @update
       def upblk():
         s.a_out @= s.comp.comp.out
+  DUT = CrossHierarchyAccessComp
 
 class CaseStarArgComp:
-  class DUT( Component ):
+  class StarArgComp( Component ):
     def construct( s, *args ):
       pass
+  DUT = StarArgComp
 
 class CaseDoubleStarArgComp:
-  class DUT( Component ):
+  class DoubleStarArgComp( Component ):
     def construct( s, **kwargs ):
       pass
+  DUT = DoubleStarArgComp


### PR DESCRIPTION
This PR implements the following
1.  fixes issues related to loading and using shared libraries compiled from external Verilog sources
2. revamps the import source code (mainly in the C++ and Python wrappers); removes out-dated code and refactors the code to be more consistent with the ECE2400 style.

Notably, this PR fixes the segfault at exit issue since we have upgraded to Verilator 5.016. This segfault appears to be a direct result of dynamically loading/unloading shared libraries which make use of thread-local variables (heavily used in Verilator 5.x). After some investigation, I believe the segfaults we saw were due to double-free effects: certain memory space allocated by thread-local variables are destructed when `dlclose()` happens AND when the program exits. The solution introduced in this PR has two aspects:
1. when loading the shared libraries, we explicitly perform a `dlopen()` with `RTLD_NODELETE` to prevent the loaded library from being unloaded by future `dlclose()`.
2. we introduce an assumption that PyMTL users should always use _unique_ class names for each Verilog design.
Rule 1 makes sure we don't experience segfaults at exit due to unloading a shared library using thread-local variables. Rule 2 prohibits the use of the same name for potentially different shared libraries, which is impossible once rule 1 is in effect.

As a side note, the solution introduced in this PR also implies we no longer need to get rid of GNU UNIQUE symbols in the generated shared libraries. These unique symbols prevent a shared library from be unloaded once they are opened, which is the desired behavior under rule 1.