### PR TITLE
Renaming ports and signals to ensure a consistent naming convention

### DIFF
--- a/examples/ex03_proc/NullXcel.py
+++ b/examples/ex03_proc/NullXcel.py
@@ -23,7 +23,7 @@ class NullXcelRTL(Component):
     s.xcel = XcelResponderIfc( xreq_class, xresp_class )
 
     s.xcelreq_q = StreamNormalQueue( xreq_class, 2 )
-    s.xcelreq_q.istream //= s.xcel.reqstream
+    s.xcelreq_q.istream //= s.xcel.req
 
     s.xr0 = RegEn( dtype )
     s.xr0.in_ //= s.xcelreq_q.ostream.msg.data
@@ -31,23 +31,23 @@ class NullXcelRTL(Component):
     @update
     def up_null_xcel():
 
-      if s.xcelreq_q.ostream.val & s.xcel.respstream.rdy:
-        s.xcelreq_q.ostream.rdy     @= 1
-        s.xcel.respstream.val       @= 1
-        s.xcel.respstream.msg.type_ @= s.xcelreq_q.ostream.msg.type_
+      if s.xcelreq_q.ostream.val & s.xcel.rsp.rdy:
+        s.xcelreq_q.ostream.rdy @= 1
+        s.xcel.rsp.val          @= 1
+        s.xcel.rsp.msg.type_    @= s.xcelreq_q.ostream.msg.type_
 
         if s.xcelreq_q.ostream.msg.type_ == XcelMsgType.WRITE:
-          s.xr0.en                   @= 1
-          s.xcel.respstream.msg.data @= 0
+          s.xr0.en            @= 1
+          s.xcel.rsp.msg.data @= 0
         else:
-          s.xr0.en                   @= 0
-          s.xcel.respstream.msg.data @= s.xr0.out
+          s.xr0.en            @= 0
+          s.xcel.rsp.msg.data @= s.xr0.out
       else:
-        s.xcelreq_q.ostream.rdy     @= 0
-        s.xcel.respstream.val       @= 0
-        s.xr0.en                    @= 0
-        s.xcel.respstream.msg.data  @= 0
-        s.xcel.respstream.msg.type_ @= 0
+        s.xcelreq_q.ostream.rdy @= 0
+        s.xcel.rsp.val          @= 0
+        s.xr0.en                @= 0
+        s.xcel.rsp.msg.data     @= 0
+        s.xcel.rsp.msg.type_    @= 0
 
   def line_trace( s ):
     return str(s.xcel)

--- a/examples/ex03_proc/ProcRTL.py
+++ b/examples/ex03_proc/ProcRTL.py
@@ -72,11 +72,11 @@ class ProcRTL( Component ):
 
     # connect all the queues
 
-    s.imemreq_q.ostream   //= s.imem.reqstream
-    s.imemresp_q.istream  //= s.imem.respstream
-    s.dmemresp_q.istream  //= s.dmem.respstream
+    s.imemreq_q.ostream   //= s.imem.req
+    s.imemresp_q.istream  //= s.imem.rsp
+    s.dmemresp_q.istream  //= s.dmem.rsp
     s.mngr2proc_q.istream //= s.mngr2proc
-    s.xcelresp_q.istream  //= s.xcel.respstream
+    s.xcelresp_q.istream  //= s.xcel.rsp
 
     # Control
 
@@ -90,17 +90,17 @@ class ProcRTL( Component ):
     m.imemresp_rdy  //= s.imemresp_drop.out.rdy
 
     # dmem port
-    m.dmemreq_val   //= s.dmem.reqstream.val
-    m.dmemreq_rdy   //= s.dmem.reqstream.rdy
-    m.dmemreq_type  //= s.dmem.reqstream.msg.type_
+    m.dmemreq_val   //= s.dmem.req.val
+    m.dmemreq_rdy   //= s.dmem.req.rdy
+    m.dmemreq_type  //= s.dmem.req.msg.type_
     m.dmemresp_val  //= s.dmemresp_q.ostream.val
     m.dmemresp_rdy  //= s.dmemresp_q.ostream.rdy
 
     # xcel port
-    m.xcelreq_type  //= s.xcel.reqstream.msg.type_
+    m.xcelreq_type  //= s.xcel.req.msg.type_
 
-    m.xcelreq_val   //= s.xcel.reqstream.val
-    m.xcelreq_rdy   //= s.xcel.reqstream.rdy
+    m.xcelreq_val   //= s.xcel.req.val
+    m.xcelreq_rdy   //= s.xcel.req.rdy
     m.xcelresp_val  //= s.xcelresp_q.ostream.val
     m.xcelresp_rdy  //= s.xcelresp_q.ostream.rdy
 
@@ -122,13 +122,13 @@ class ProcRTL( Component ):
     m.imemresp_data //= s.imemresp_drop.out.msg
 
     # dmem ports
-    m.dmemreq_addr  //= s.dmem.reqstream.msg.addr
-    m.dmemreq_data  //= s.dmem.reqstream.msg.data
+    m.dmemreq_addr  //= s.dmem.req.msg.addr
+    m.dmemreq_data  //= s.dmem.req.msg.data
     m.dmemresp_data //= s.dmemresp_q.ostream.msg.data
 
     # xcel ports
-    m.xcelreq_addr  //= s.xcel.reqstream.msg.addr
-    m.xcelreq_data  //= s.xcel.reqstream.msg.data
+    m.xcelreq_addr  //= s.xcel.req.msg.addr
+    m.xcelreq_data  //= s.xcel.req.msg.data
     m.xcelresp_data //= s.xcelresp_q.ostream.msg.data
 
     # mngr

--- a/examples/ex04_xcel/ChecksumXcelRTL.py
+++ b/examples/ex04_xcel/ChecksumXcelRTL.py
@@ -42,7 +42,7 @@ class ChecksumXcelRTL( Component ):
 
     # Connections
 
-    s.xcel.reqstream //= s.in_q.istream
+    s.xcel.req //= s.in_q.istream
     s.checksum_unit.istream.msg[0 :32 ] //= s.reg_file[0].out
     s.checksum_unit.istream.msg[32:64 ] //= s.reg_file[1].out
     s.checksum_unit.istream.msg[64:96 ] //= s.reg_file[2].out
@@ -52,7 +52,7 @@ class ChecksumXcelRTL( Component ):
 
     @update
     def up_start_pulse():
-      s.start_pulse @=   (s.xcel.respstream.val & s.xcel.respstream.rdy) & \
+      s.start_pulse @=   (s.xcel.rsp.val & s.xcel.rsp.rdy) & \
                        ( s.in_q.ostream.msg.type_ == XcelMsgType.WRITE ) & \
                        ( s.in_q.ostream.msg.addr == 4 )
 
@@ -82,28 +82,28 @@ class ChecksumXcelRTL( Component ):
     def up_fsm_output():
       if s.state == s.XCFG:
         s.in_q.ostream.rdy @= s.in_q.ostream.val
-        s.xcel.respstream.val @= s.in_q.ostream.val
+        s.xcel.rsp.val @= s.in_q.ostream.val
         s.checksum_unit.istream.val @= s.start_pulse & s.checksum_unit.istream.rdy
         s.checksum_unit.ostream.rdy @= 1
 
       elif s.state == s.WAIT:
         s.in_q.ostream.rdy @= 0
-        s.xcel.respstream.val @= 0
+        s.xcel.rsp.val @= 0
         s.checksum_unit.istream.val @= s.checksum_unit.istream.rdy
         s.checksum_unit.ostream.rdy @= 1
 
       else: # s.state == s.BUSY:
         s.in_q.ostream.rdy  @= 0
-        s.xcel.respstream.val @= 0
+        s.xcel.rsp.val @= 0
         s.checksum_unit.istream.val @= 0
         s.checksum_unit.ostream.rdy @= 1
 
     @update
     def up_resp_msg():
-      s.xcel.respstream.msg.type_ @= s.in_q.ostream.msg.type_
-      s.xcel.respstream.msg.data  @= 0
+      s.xcel.rsp.msg.type_ @= s.in_q.ostream.msg.type_
+      s.xcel.rsp.msg.data  @= 0
       if s.in_q.ostream.msg.type_ == XcelMsgType.READ:
-        s.xcel.respstream.msg.data @= s.reg_file[ s.in_q.ostream.msg.addr[0:3] ].out
+        s.xcel.rsp.msg.data @= s.reg_file[ s.in_q.ostream.msg.addr[0:3] ].out
 
     @update
     def up_wr_regfile():
@@ -127,4 +127,4 @@ class ChecksumXcelRTL( Component ):
       "BUSY" if s.state == s.BUSY else
       "XXXX"
     )
-    return "{}(RTL:{}){}".format( s.xcel.reqstream, state_str, s.xcel.respstream )
+    return "{}(RTL:{}){}".format( s.xcel.req, state_str, s.xcel.rsp )

--- a/examples/ex04_xcel/test/ChecksumXcelRTL_test.py
+++ b/examples/ex04_xcel/test/ChecksumXcelRTL_test.py
@@ -67,23 +67,23 @@ def checksum_xcel_rtl( words ):
   for req in reqs:
 
     # Wait until xcel is ready to accept a request
-    dut.xcel.respstream.rdy @= 1
-    while not dut.xcel.reqstream.rdy:
-      dut.xcel.reqstream.val @= 0
+    dut.xcel.rsp.rdy @= 1
+    while not dut.xcel.req.rdy:
+      dut.xcel.req.val @= 0
       dut.sim_tick()
 
     # Send a request
-    dut.xcel.reqstream.val @= 1
-    dut.xcel.reqstream.msg @= req
+    dut.xcel.req.val @= 1
+    dut.xcel.req.msg @= req
     dut.sim_tick()
 
     # Wait for response
-    while not dut.xcel.respstream.val:
-      dut.xcel.reqstream.val @= 0
+    while not dut.xcel.rsp.val:
+      dut.xcel.req.val @= 0
       dut.sim_tick()
 
     # Get the response message
-    resp_data = dut.xcel.respstream.msg.data
+    resp_data = dut.xcel.rsp.msg.data
 
   return resp_data
 
@@ -125,8 +125,8 @@ class TestHarness( Component ):
     s.dut  = DutType()
     s.sink = StreamSinkFL( RespType, sink_msgs )
 
-    connect( s.src.ostream,      s.dut.xcel.reqstream )
-    connect( s.dut.xcel.respstream, s.sink.istream    )
+    connect( s.src.ostream,  s.dut.xcel.req )
+    connect( s.dut.xcel.rsp, s.sink.istream )
 
   def done( s ):
     return s.src.done() and s.sink.done()

--- a/examples/ex04_xcel/test/ChecksumXcelVRTL_test.py
+++ b/examples/ex04_xcel/test/ChecksumXcelVRTL_test.py
@@ -45,23 +45,23 @@ def checksum_xcel_vrtl( words ):
   for req in reqs:
 
     # Wait until xcel is ready to accept a request
-    dut.xcel.respstream.rdy @= 1
-    while not dut.xcel.reqstream.rdy:
-      dut.xcel.reqstream.val @= 0
+    dut.xcel.rsp.rdy @= 1
+    while not dut.xcel.req.rdy:
+      dut.xcel.req.val @= 0
       dut.sim_tick()
 
     # Send a request
-    dut.xcel.reqstream.val @= 1
-    dut.xcel.reqstream.msg @= req
+    dut.xcel.req.val @= 1
+    dut.xcel.req.msg @= req
     dut.sim_tick()
 
     # Wait for response
-    while not dut.xcel.respstream.val:
-      dut.xcel.reqstream.val @= 0
+    while not dut.xcel.rsp.val:
+      dut.xcel.req.val @= 0
       dut.sim_tick()
 
     # Get the response message
-    resp_data = dut.xcel.respstream.msg.data
+    resp_data = dut.xcel.rsp.msg.data
     dut.sim_tick()
 
   return resp_data

--- a/pymtl3/stdlib/mem/MemRequesterAdapterFL.py
+++ b/pymtl3/stdlib/mem/MemRequesterAdapterFL.py
@@ -64,7 +64,7 @@ class MemRequesterAdapterFL( Component ):
 
     @update_ff
     def up_req_sent():
-      s.req_sent <<= s.requester.reqstream.val & s.requester.reqstream.rdy
+      s.req_sent <<= s.requester.req.val & s.requester.req.rdy
 
     @update
     def up_clear_req():
@@ -74,20 +74,20 @@ class MemRequesterAdapterFL( Component ):
     @update_once
     def up_send_req():
       if s.req_entry is None:
-        s.requester.reqstream.val @= 0
+        s.requester.req.val @= 0
       else:
-        s.requester.reqstream.val @= 1
-        s.requester.reqstream.msg @= s.req_entry
+        s.requester.req.val @= 1
+        s.requester.req.msg @= s.req_entry
 
     # resp path
     @update_once
     def up_resp_rdy():
-      s.requester.respstream.rdy @= (s.resp_entry is None)
+      s.requester.rsp.rdy @= (s.resp_entry is None)
 
     @update_once
     def up_resp_msg():
-      if (s.resp_entry is None) & s.requester.respstream.val:
-        s.resp_entry = clone_deepcopy( s.requester.respstream.msg )
+      if (s.resp_entry is None) & s.requester.rsp.val:
+        s.resp_entry = clone_deepcopy( s.requester.rsp.msg )
 
     s.add_constraints( U( up_clear_req ) < M(s.read),
                        U( up_clear_req ) < M(s.write),

--- a/pymtl3/stdlib/mem/MemoryFL.py
+++ b/pymtl3/stdlib/mem/MemoryFL.py
@@ -150,9 +150,9 @@ class MemoryFL( Component ):
     s.resp_qs    = [ InelasticDelayPipe( resp_classes[i], extra_latency+1 ) for i in range(nports) ]
 
     for i in range(nports):
-      s.req_stalls[i].istream //= s.ifc[i].reqstream
+      s.req_stalls[i].istream //= s.ifc[i].req
       # s.req_stalls[i].ostream //= s.req_qs[i].istream
-      s.resp_qs[i].ostream    //= s.ifc[i].respstream
+      s.resp_qs[i].ostream    //= s.ifc[i].rsp
 
       s.req_stalls[i].ostream.rdy //= s.resp_qs[i].istream.rdy
       s.req_stalls[i].ostream.val //= s.resp_qs[i].istream.val
@@ -211,6 +211,5 @@ class MemoryFL( Component ):
   #-----------------------------------------------------------------------
 
   def line_trace( s ):
-    # print()
-    return "|".join( f"{s.req_stalls[i].line_trace()}{s.ifc[i].reqstream}>{s.ifc[i].respstream}{s.resp_qs[i].line_trace()}"
+    return "|".join( f"{s.req_stalls[i].line_trace()}{s.ifc[i].req}>{s.ifc[i].rsp}{s.resp_qs[i].line_trace()}"
                         for i in range(len(s.ifc)) )

--- a/pymtl3/stdlib/mem/test/MemoryFL_test.py
+++ b/pymtl3/stdlib/mem/test/MemoryFL_test.py
@@ -32,8 +32,8 @@ class TestHarness( Component ):
 
     # Connections
     for i in range(nports):
-      connect( s.srcs[i].ostream, s.mem.ifc[i].reqstream )
-      connect( s.mem.ifc[i].respstream, s.sinks[i].istream )
+      connect( s.srcs[i].ostream, s.mem.ifc[i].req )
+      connect( s.mem.ifc[i].rsp, s.sinks[i].istream )
 
   def done( s ):
     return all([x.done() for x in s.srcs] + [x.done() for x in s.sinks])

--- a/pymtl3/stdlib/reqresp/ifcs/ifcs.py
+++ b/pymtl3/stdlib/reqresp/ifcs/ifcs.py
@@ -16,19 +16,19 @@ class RequesterIfc( Interface ):
   def construct( s, ReqType, RespType ):
     s.ReqType  = ReqType
     s.RespType = RespType
-    s.reqstream  = OStreamIfc( Type=ReqType )
-    s.respstream = IStreamIfc( Type=RespType )
+    s.req = OStreamIfc( Type=ReqType )
+    s.rsp = IStreamIfc( Type=RespType )
 
   def __str__( s ):
-    return f"{s.reqstream}|{s.respstream}"
+    return f"{s.req}|{s.rsp}"
 
 class ResponderIfc( Interface ):
 
   def construct( s, ReqType, RespType ):
     s.ReqType  = ReqType
     s.RespType = RespType
-    s.reqstream  = IStreamIfc( Type=ReqType )
-    s.respstream = OStreamIfc( Type=RespType )
+    s.req = IStreamIfc( Type=ReqType )
+    s.rsp = OStreamIfc( Type=RespType )
 
   def __str__( s ):
-    return f"{s.reqstream}|{s.respstream}"
+    return f"{s.req}|{s.rsp}"

--- a/pymtl3/stdlib/xcel/XcelRequesterAdapterFL.py
+++ b/pymtl3/stdlib/xcel/XcelRequesterAdapterFL.py
@@ -48,7 +48,7 @@ class XcelRequesterAdapterFL( Component ):
 
     @update_ff
     def up_req_sent():
-      s.req_sent <<= s.requester.reqstream.val & s.requester.reqstream.rdy
+      s.req_sent <<= s.requester.req.val & s.requester.req.rdy
 
     @update
     def up_clear_req():
@@ -58,20 +58,20 @@ class XcelRequesterAdapterFL( Component ):
     @update_once
     def up_send_req():
       if s.req_entry is None:
-        s.requester.reqstream.val @= 0
+        s.requester.req.val @= 0
       else:
-        s.requester.reqstream.val @= 1
-        s.requester.reqstream.msg @= s.req_entry
+        s.requester.req.val @= 1
+        s.requester.req.msg @= s.req_entry
 
     # resp path
     @update_once
     def up_resp_rdy():
-      s.requester.respstream.rdy @= (s.resp_entry is None)
+      s.requester.rsp.rdy @= (s.resp_entry is None)
 
     @update_once
     def up_resp_msg():
-      if (s.resp_entry is None) & s.requester.respstream.val:
-        s.resp_entry = clone_deepcopy( s.requester.respstream.msg )
+      if (s.resp_entry is None) & s.requester.rsp.val:
+        s.resp_entry = clone_deepcopy( s.requester.rsp.msg )
 
     s.add_constraints( U( up_clear_req ) < M(s.read),
                        U( up_clear_req ) < M(s.write),


### PR DESCRIPTION
This PR implements the following signal and port name changes to ensure a consistent naming convention:

- [ ] reqstream/respstream -> req/rsp
- [ ] reset -> rst
- [ ] req/resp -> req/rsp

With this PR, we will be using three-letter names across important ports/signals: clk, rst, val, rdy, req, rsp.