### PR TITLE
Add support for Verilator assertion

### DIFF
--- a/pymtl3/passes/backends/verilog/import_/test/ImportedObject_test.py
+++ b/pymtl3/passes/backends/verilog/import_/test/ImportedObject_test.py
@@ -524,3 +524,26 @@ def test_incr_on_demand_vcd( do_test ):
     a.sim_tick()
 
   a.finalize()
+
+def test_vl_assertion( do_test ):
+  class VAssert( Component, VerilogPlaceholder ):
+    def construct( s ):
+      s.in_ = InPort( 10 )
+      s.out = OutPort( 10 )
+      s.set_metadata( VerilogPlaceholderPass.src_file, dirname(__file__)+'/VAssert.v' )
+  a = VAssert()
+  a.elaborate()
+  a.apply( VerilogPlaceholderPass() )
+  a = VerilogTranslationImportPass()( a )
+  a.apply( DefaultPassGroup(linetrace=True) )
+
+  try:
+    for i in range(16):
+      a.in_ @= Bits10(i)
+      a.sim_tick()
+  except AssertionError as e:
+    return
+  finally:
+    a.finalize()
+
+  raise Exception("Should have thrown a Verilator assertion error!")

--- a/pymtl3/passes/backends/verilog/import_/test/VAssert.v
+++ b/pymtl3/passes/backends/verilog/import_/test/VAssert.v
@@ -1,0 +1,12 @@
+module test_VAssert (
+  input [9:0] in_,
+  output logic [9:0] out
+);
+
+  assign out = in_;
+
+  always_comb begin
+    assert (in_ != 4);
+  end
+
+endmodule

--- a/pymtl3/passes/backends/verilog/import_/verilator_wrapper_py_template.py
+++ b/pymtl3/passes/backends/verilog/import_/verilator_wrapper_py_template.py
@@ -59,7 +59,8 @@ class {component_name}( Component ):
       void V{component_name}_destroy_model( V{component_name}_t *);
       void V{component_name}_comb_eval( V{component_name}_t * );
       void V{component_name}_seq_eval( V{component_name}_t * );
-      void V{component_name}_assert_en( bool en );
+      void V{component_name}_assert_on( V{component_name}_t *, bool );
+      bool V{component_name}_has_assert_fired( V{component_name}_t * );
       {trace_c_def}
 
     """)
@@ -170,17 +171,12 @@ class {component_name}( Component ):
       # seq_eval will automatically tick clock in C land
       _ffi_inst_seq_eval( _ffi_m )
 
-  def assert_en( s, en ):
-    # TODO: for verilator, any assertion failure will cause the C simulator
-    # to abort, which results in a Python internal error. A better approach
-    # is to throw a Python exception at the time of assertion failure.
-    # Verilator allows user-defined `stop` function which is called when
-    # the simulation is expected to stop due to various reasons. We might
-    # be able to raise a Python exception through Python C API (although
-    # at this moment I'm not sure if the C API's are compatible between
-    # PyPy and CPython).
-    assert isinstance( en, bool )
-    s._ffi_inst.V{component_name}_assert_en( s._ffi_m, en )
+      if s._ffi_inst.V{component_name}_has_assert_fired( _ffi_m ):
+        raise AssertionError("A Verilog assertion fired in the Verilator simulation!")
+
+  def assert_on( s, enable ):
+    assert isinstance( enable, bool )
+    s._ffi_inst.V{component_name}_assert_on( s._ffi_m, enable )
 
   def line_trace( s ):
     if {external_trace}:


### PR DESCRIPTION
This PR adds support for firing assertions in Verilator.

With this PR, the Python wrapper checks if an assertion has fired in the current Verilator context towards the end of a clock cycle. If an assertion has fired, the Python wrapper raises an assertion error. This behavior allows use of Verilator assertions without crashing the entire process.