### PR TITLE
Improve index handling in Bits and Signal classes

### DIFF
--- a/pymtl3/datatypes/PythonBits.py
+++ b/pymtl3/datatypes/PythonBits.py
@@ -133,6 +133,8 @@ class Bits:
         raise IndexError( "Index cannot contain step" )
       try:
         start, stop = int(idx.start or 0), int(idx.stop or self._nbits)
+        if start is None: start = 0
+        if stop is None: stop = self._nbits
         assert 0 <= start < stop <= self._nbits
       except:
         raise IndexError( f"Invalid access: [{idx.start}:{idx.stop}] in a Bits{self._nbits} instance" )

--- a/pymtl3/datatypes/test/bits_test.py
+++ b/pymtl3/datatypes/test/bits_test.py
@@ -704,6 +704,12 @@ def test_slice_bits():
   with pytest.raises( IndexError ):
     assert data[x:x] == 0b1
 
+def test_slice_bits_int():
+  data = Bits(8, 0b1101)
+  assert data[:2] == 0b01
+  assert data[2:] == 0b11
+
+
 def test_clone():
   a = Bits(4,3)
   b = a.clone()

--- a/pymtl3/dsl/AstHelper.py
+++ b/pymtl3/dsl/AstHelper.py
@@ -61,8 +61,7 @@ class DetectVarNames( ast.NodeVisitor ):
         if   x in self.globals: up = (False, x)
         elif x in self.closure: up = (True, x)
 
-      if low is not None and up is not None:
-        slices.append( slice(low, up) )
+      slices.append( slice(low, up) )
       # FIXME
       # else:
 
@@ -160,8 +159,7 @@ class DetectVarNames( ast.NodeVisitor ):
         if   x in self.globals: up = (False, x)
         elif x in self.closure: up = (True, x)
 
-      if low is not None and up is not None:
-        slices.append( slice(low, up) )
+      slices.append( slice(low, up) )
       # FIXME
       # else:
 

--- a/pymtl3/dsl/Connectable.py
+++ b/pymtl3/dsl/Connectable.py
@@ -261,6 +261,8 @@ class Signal( NamedObject, Connectable ):
       start, stop = idx, idx + 1
     elif isinstance( idx, slice ):
       start, stop = idx.start, idx.stop
+      if start is None: start = 0
+      if stop  is None: stop  = s._dsl.Type.nbits
     else: assert False, f"The slice {idx} is invalid"
 
     if s._dsl.slice is None:

--- a/pymtl3/dsl/test/Slicing_test.py
+++ b/pymtl3/dsl/test/Slicing_test.py
@@ -127,9 +127,7 @@ def test_write_two_slices_and_bit():
       def up_rd_A():
         print(s.A[0:17])
 
-  m = Top()
-  m.elaborate()
-  simple_sim_pass( m, 0x123 )
+  _test_model( Top )
 
   # assert len(m._all_constraints) == 2
   # _, x = list(m._all_constraints)[0]
@@ -164,6 +162,23 @@ def test_write_slices_and_bit_overlapped():
     print("{} is thrown\n{}".format( e.__class__.__name__, e ))
     return
   raise Exception("Should've thrown MultiWriterError.")
+
+# test slicing without specified width
+def test_write_two_slices_and_bit_without_specifying_width():
+
+  class Top( ComponentLevel3 ):
+    def construct( s ):
+      s.A  = Wire( Bits32 )
+
+      @update
+      def up_wr_0_16():
+        s.A[:16] @= 0xff
+
+      @update
+      def up_wr_16_32():
+        s.A[16:] @= 0xff
+
+  _test_model(Top)
 
 # write a slice and there are two reader
 def test_multiple_readers():


### PR DESCRIPTION
Enable syntax like `a[0:]` and `a[:n]`, an often useful feature. 

Please let me know if any other place will require such a change. 