### PR TITLE
fixing verilog placeholder pass

### DIFF
--- a/pymtl3/passes/backends/verilog/VerilogPlaceholderConfigs.py
+++ b/pymtl3/passes/backends/verilog/VerilogPlaceholderConfigs.py
@@ -47,6 +47,12 @@ class VerilogPlaceholderConfigs( PlaceholderConfigs ):
 
     # The separator used for name mangling
     "separator" : '__',
+
+    # The name of the clock signal
+    "clk_name" : "clk",
+
+    # The name of the reset signal
+    "reset_name" : "rst",
   }
 
   VerilogCheckers = {
@@ -65,6 +71,11 @@ class VerilogPlaceholderConfigs( PlaceholderConfigs ):
 
     "v_include": Checker( lambda v: isinstance(v, list) and all(os.path.isdir(expand(p)) for p in v),
                             "expects a list of paths to directory"),
+    
+    "has_clk": Checker( lambda v: isinstance(v, bool), "expects a bool" ),
+    "has_reset": Checker( lambda v: isinstance(v, bool), "expects a bool" ),
+    "clk_name": Checker( lambda v: isinstance(v, str) and v, "expects a non-empty string" ),
+    "reset_name": Checker( lambda v: isinstance(v, str) and v, "expects a non-empty string" ),
   }
 
   Pass = VerilogPlaceholderPass

--- a/pymtl3/passes/backends/verilog/VerilogPlaceholderPass.py
+++ b/pymtl3/passes/backends/verilog/VerilogPlaceholderPass.py
@@ -89,6 +89,18 @@ class VerilogPlaceholderPass( PlaceholderPass ):
   #: Default value: ``'_'``
   separator  = MetadataKey(str)
 
+  #: has clk
+  has_clk    = MetadataKey(bool)
+
+  #: has reset
+  has_reset  = MetadataKey(bool)
+
+  #: clk name
+  clk_name   = MetadataKey(str)
+
+  #: reset name
+  reset_name = MetadataKey(str)
+
   @staticmethod
   def get_placeholder_config():
     from pymtl3.passes.backends.verilog.VerilogPlaceholderConfigs import (
@@ -338,10 +350,17 @@ class VerilogPlaceholderPass( PlaceholderPass ):
     ]
 
     # Connections between top module and inner module
-    connect_ports = [
+    connect_ports = []
+    if s.has_clk:
+      connect_ports.append(f"    .{cfg.clk_name}( clk )," )
+
+    if s.has_reset:
+      connect_ports.append(f"    .{cfg.reset_name}( reset )," )
+    connect_ports.extend([
       f"    .{name}( {name} ){'' if idx == len(rtlir_ports)-1 else ','}"\
       for idx, (_, name, p, _) in enumerate(rtlir_ports) if name
-    ]
+    ])
+
 
     lines = [
       f"module {cfg.pickled_top_module}",


### PR DESCRIPTION
The placeholder pass wrapper does not add a clock and reset signal, even when the metadata is set,  which causes a missing pin warning from Verilator. 

Furthermore, the name of the clock and reset might vary between designs; two new parameters are added so that the user can define the name of the clock signal and the reset signal. 

