### PR TITLE
Improving concat

### DIFF
--- a/pymtl3/datatypes/helpers.py
+++ b/pymtl3/datatypes/helpers.py
@@ -9,6 +9,7 @@ Author : Shunning Jiang
 Date   : Nov 3, 2017
 """
 import math
+import types
 
 from .bits_import import *
 
@@ -18,7 +19,14 @@ except:
   def concat( *args ):
     value = nbits = 0
 
+    if len(args) == 1:
+      if isinstance(args[0], list):
+        args = args[0]
+      elif isinstance(args[0], types.GeneratorType):
+        args = args[0]
+
     for x in args:
+      print(x)
       xnb = x.nbits
       nbits += xnb
       value = (value << xnb) | x.uint()

--- a/pymtl3/datatypes/helpers.py
+++ b/pymtl3/datatypes/helpers.py
@@ -26,7 +26,6 @@ except:
         args = args[0]
 
     for x in args:
-      print(x)
       xnb = x.nbits
       nbits += xnb
       value = (value << xnb) | x.uint()

--- a/pymtl3/datatypes/test/helpers_test.py
+++ b/pymtl3/datatypes/test/helpers_test.py
@@ -17,6 +17,17 @@ def test_concat():
   assert x.nbits == 380
   assert x == mk_bits(380)(0x1234567890abcdef1234567890abcdeffffffffff22222222222222222444441234567890abcdef1234567890abcdef)
 
+def test_concat_list():
+  x = concat([Bits2(2) for _ in range(4)])
+  assert x.nbits == 8
+  assert x == Bits8(0b10101010)
+
+
+def test_concat_generator():
+  x = concat(Bits2(2) for _ in range(4))
+  assert x.nbits == 8
+  assert x == Bits8(0b10101010)
+
 def test_zext():
   assert zext( Bits8(0xe), 24 ) == Bits24(0xe)
 


### PR DESCRIPTION
Allowing concat to take list or generator to enable syntax like `s.a //= concat(b2(1) for _ in range(4))` to be used. 