### PR TITLE
Fix deprecated ast warning 

### DIFF
--- a/pymtl3/dsl/AstHelper.py
+++ b/pymtl3/dsl/AstHelper.py
@@ -145,15 +145,15 @@ class DetectVarNames( ast.NodeVisitor ):
 
       low = up = None
 
-      if isinstance( lower, ast.Num ):
-        low = node.slice.lower.n
+      if isinstance( lower, ast.Constant ):
+        low = node.slice.lower.value
       elif isinstance( lower, ast.Name ):
         x = lower.id
         if   x in self.globals: low = (False, x)
         elif x in self.closure: low = (True, x)
 
-      if isinstance( upper, ast.Num ):
-        up = node.slice.upper.n
+      if isinstance( upper, ast.Constant ):
+        up = node.slice.upper.value
       elif isinstance( upper, ast.Name ):
         x = upper.id
         if   x in self.globals: up = (False, x)
@@ -175,8 +175,8 @@ class DetectVarNames( ast.NodeVisitor ):
 
         if isinstance( v, ast.Attribute ): # s.sel, may be constant
           self.visit( v )
-        elif isinstance( v, ast.Num ):
-          n = v.n
+        elif isinstance( v, ast.Constant ):
+          n = v.value
         elif isinstance( v, ast.Name ):
           x = v.id
           if   x in self.globals: n = (False, x)

--- a/pymtl3/dsl/ComponentLevel3.py
+++ b/pymtl3/dsl/ComponentLevel3.py
@@ -146,8 +146,8 @@ class ComponentLevel3( ComponentLevel2 ):
                     lineno=1+idx, col_offset=5+len(var),
                   ),
                   slice=ast.Index(
-                    value=ast.Num(
-                      n=idx,
+                    value=ast.Constant(
+                      value=idx,
                       lineno=1+idx, col_offset=19+len(var),
                     ),
                   ),


### PR DESCRIPTION
Fix the deprecated AST warning. This will be useful for the feature as pytml3 will not work with python3.14 without this fix. 
