### PR TITLE
Fix clog2 function to be fast and universal

### DIFF
--- a/pymtl3/datatypes/helpers.py
+++ b/pymtl3/datatypes/helpers.py
@@ -42,8 +42,8 @@ def zext( value, new_width ):
     return new_width( value.uint() )
 
 def clog2( N ):
-  assert N > 0
-  return int( math.ceil( math.log( N, 2 ) ) )
+  assert N > 0  
+  return (N - 1).bit_length()
 
 def sext( value, new_width ):
   if isinstance( new_width, int ):


### PR DESCRIPTION
Using floor of log2 with IEEE double floats here, suffers slowness and inaccuracy at huge values where the log2 would round incorrectly due a 53-bit mantissa.