### PR TITLE
Output VCD file compliant with the standard

### DIFF
--- a/pymtl3/datatypes/PythonBits.py
+++ b/pymtl3/datatypes/PythonBits.py
@@ -530,7 +530,18 @@ class Bits:
     str = "{:x}".format(int(self._uint)).zfill(((self._nbits-1)//4)+1)
     return "0x"+str
 
-  def bin_vcd( self ):
-    str = "{:b}".format(int(self._uint)).zfill(self._nbits)
+  # Output string suitable for use in VCD file. Single-bit nets are
+  # encoded as a single 0/1 with no trailing space. Multi-bit nets are
+  # encoded as b0000 (where 0000 are the values for a four-bit net) and a
+  # trailing space. This enables the symbol to be concatentated at the
+  # end of this string and we either have the required space (i.e., for
+  # multi-bit nets) or we do not have any space (i.e., for single-bit
+  # nets). -cbatten
+
+  def to_vcd_str( self ):
+    if self._nbits == 1:
+      str = f"{int(self._uint):b}"
+    else:
+      str = f"b{int(self._uint):0{self._nbits}b} "
     return str
 

--- a/pymtl3/datatypes/PythonBits.py
+++ b/pymtl3/datatypes/PythonBits.py
@@ -529,3 +529,8 @@ class Bits:
   def hex( self ):
     str = "{:x}".format(int(self._uint)).zfill(((self._nbits-1)//4)+1)
     return "0x"+str
+
+  def bin_vcd( self ):
+    str = "{:b}".format(int(self._uint)).zfill(self._nbits)
+    return str
+

--- a/pymtl3/datatypes/test/bits_test.py
+++ b/pymtl3/datatypes/test/bits_test.py
@@ -760,3 +760,5 @@ def test_bin_oct_hex():
   assert Bits(15,35).bin() == "0b000000000100011"
   assert Bits(15,35).oct() == "0o00043"
   assert Bits(15,35).hex() == "0x0023"
+  assert Bits(15,35).bin_vcd() == "000000000100011"
+

--- a/pymtl3/datatypes/test/bits_test.py
+++ b/pymtl3/datatypes/test/bits_test.py
@@ -760,5 +760,23 @@ def test_bin_oct_hex():
   assert Bits(15,35).bin() == "0b000000000100011"
   assert Bits(15,35).oct() == "0o00043"
   assert Bits(15,35).hex() == "0x0023"
-  assert Bits(15,35).bin_vcd() == "000000000100011"
+
+def test_to_vcd_str():
+
+  assert Bits(1,0).to_vcd_str() == "0"
+  assert Bits(1,1).to_vcd_str() == "1"
+  assert Bits(1,0).to_vcd_str() == "0"
+  assert Bits(1,1).to_vcd_str() == "1"
+
+  assert Bits(2,0).to_vcd_str() == "b00 "
+  assert Bits(2,1).to_vcd_str() == "b01 "
+  assert Bits(2,2).to_vcd_str() == "b10 "
+  assert Bits(2,3).to_vcd_str() == "b11 "
+  assert Bits(2,0).to_vcd_str() == "b00 "
+  assert Bits(2,1).to_vcd_str() == "b01 "
+  assert Bits(2,2).to_vcd_str() == "b10 "
+  assert Bits(2,3).to_vcd_str() == "b11 "
+
+  assert Bits(15,35).to_vcd_str() == "b000000000100011 "
+  assert Bits(15,35).to_vcd_str() == "b000000000100011 "
 

--- a/pymtl3/passes/tracing/VcdGenerationPass.py
+++ b/pymtl3/passes/tracing/VcdGenerationPass.py
@@ -202,9 +202,9 @@ class VcdGenerationPass( BasePass ):
     for i, net in enumerate(trimmed_value_nets):
       # Convert everything to Bits to get around lack of bit struct support.
       # The first cycle VCD contains the default value
-      bin_str = net[0]._dsl.Type().to_bits().bin_vcd()
+      bin_str = net[0]._dsl.Type().to_bits().to_vcd_str()
 
-      print( f"b{bin_str} {net_symbol_mapping[i]}", file=vcd_file )
+      print( f"{bin_str}{net_symbol_mapping[i]}", file=vcd_file )
 
       # Set this to be the last cycle value str
       last_values[i] = bin_str
@@ -243,13 +243,13 @@ class VcdGenerationPass( BasePass ):
         except Exception as e:
           raise TypeError(f'{e}\n - {signal} becomes another type. Please check your code.')
 
-        net_bits_bin_str = net_bits_bin.bin_vcd()
+        net_bits_bin_str = net_bits_bin.to_vcd_str()
         # `last_value` is the string form of a Bits object in binary
-        # e.g. '000' == Bits3(0).bin_vcd()
+        # e.g. '000' == Bits3(0).to_vcd_str()
         # We store strings instead of values ...
         if last_values[i] != net_bits_bin_str:
           last_values[i] = net_bits_bin_str
-          print( f'b{net_bits_bin_str} {symbol}', file=vcd_file )
+          print( f'{net_bits_bin_str}{symbol}', file=vcd_file )
 
       # Flop clock at the end of cycle
       next_neg_edge = 100 * vcd_sim_ncycles + 50

--- a/pymtl3/passes/tracing/VcdGenerationPass.py
+++ b/pymtl3/passes/tracing/VcdGenerationPass.py
@@ -202,7 +202,7 @@ class VcdGenerationPass( BasePass ):
     for i, net in enumerate(trimmed_value_nets):
       # Convert everything to Bits to get around lack of bit struct support.
       # The first cycle VCD contains the default value
-      bin_str = net[0]._dsl.Type().to_bits().bin()
+      bin_str = net[0]._dsl.Type().to_bits().bin_vcd()
 
       print( f"b{bin_str} {net_symbol_mapping[i]}", file=vcd_file )
 
@@ -221,7 +221,7 @@ class VcdGenerationPass( BasePass ):
                       if i != vcd_clock_net_idx ]
 
     # Flip clock for the first cycle
-    print( '\n#0\nb0b1 {}\n'.format( clock_symbol ), file=vcd_file, flush=True )
+    print( '\n#0\n1{}\n'.format( clock_symbol ), file=vcd_file, flush=True )
 
     # Returns a dump_vcd function that is ready to be appended to _sched.
     # TODO: type check?
@@ -243,9 +243,9 @@ class VcdGenerationPass( BasePass ):
         except Exception as e:
           raise TypeError(f'{e}\n - {signal} becomes another type. Please check your code.')
 
-        net_bits_bin_str = net_bits_bin.bin()
+        net_bits_bin_str = net_bits_bin.bin_vcd()
         # `last_value` is the string form of a Bits object in binary
-        # e.g. '0b000' == Bits3(0).bin()
+        # e.g. '000' == Bits3(0).bin_vcd()
         # We store strings instead of values ...
         if last_values[i] != net_bits_bin_str:
           last_values[i] = net_bits_bin_str
@@ -253,11 +253,11 @@ class VcdGenerationPass( BasePass ):
 
       # Flop clock at the end of cycle
       next_neg_edge = 100 * vcd_sim_ncycles + 50
-      print( f'\n#{next_neg_edge}\nb0b0 {clock_symbol}', file=vcd_file )
+      print( f'\n#{next_neg_edge}\n0{clock_symbol}', file=vcd_file )
 
       # Flip clock of the next cycle
       next_pos_edge = next_neg_edge + 50
-      print( f'#{next_pos_edge}\nb0b1 {clock_symbol}\n', file=vcd_file, flush=True )
+      print( f'#{next_pos_edge}\n1{clock_symbol}\n', file=vcd_file, flush=True )
       vcd_sim_ncycles += 1
 
     def gen_dump_vcd( s ):


### PR DESCRIPTION
PyMTL3 was generating an incorrect VCD format that just happened to work with GTKWave. The old version would output nets as:
```
b0b0 !
b0b0001 $
```
So every net had an extra `b0` at the beginning. In addition, single-bit nets should be represented by either 0 or 1 and then the symbol with no space. This pull request fixes this issue so that PyMTL3 now outputs:
```
0!
b0001 $
```